### PR TITLE
Set `net.offline` in .cargo/config.toml according to value of :offline

### DIFF
--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -666,6 +666,7 @@ impl EvalContext {
 
     pub(crate) fn write_cargo_toml(&self, state: &ContextState) -> Result<()> {
         self.module.write_cargo_toml(state)?;
+        self.module.write_config_toml(state)?;
         Ok(())
     }
 
@@ -1132,7 +1133,7 @@ impl ContextState {
         self.config.preserve_vars_on_panic
     }
 
-    pub fn offline_mode(&mut self) -> bool {
+    pub fn offline_mode(&self) -> bool {
         self.config.offline_mode
     }
 

--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -134,6 +134,17 @@ impl Module {
             &self.get_cargo_toml_contents(state),
         )
     }
+    
+    // Writes .cargo/config.toml. Should be called before compile.
+    pub(crate) fn write_config_toml(&self, state: &ContextState) -> Result<(), Error> {
+        let dot_config_dir = self.crate_dir().join(".cargo");
+        fs::create_dir_all(dot_config_dir.as_path())?;
+        write_file(
+           dot_config_dir.as_path(),
+            "config.toml",
+            &self.get_config_toml_contents(state),
+        )
+    }
 
     pub(crate) fn check(
         &mut self,
@@ -264,8 +275,18 @@ overflow-checks = true
             crate_imports
         )
     }
-}
 
+    // Pass offline mode to cargo through .cargo/config.toml
+    fn get_config_toml_contents(&self, state: &ContextState) -> String {
+        format!(
+            r#"
+[net]
+offline = {}
+"#,
+            state.offline_mode()
+        )
+    }
+}
 fn run_cargo(
     mut command: std::process::Command,
     code_block: &CodeBlock,


### PR DESCRIPTION
- Without this, rust analyzer's cargo operations (e.g. cargo meta) still tries to access the network.
- Note - `:offline 1 or 0` does not update the .config right away. It's written together when `Cargo.toml` is updated.
- Fixes #265 