### PR TITLE
Suggest offline mode when adding dependency fails

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -463,7 +463,7 @@ Panic detected. Here's some useful information if you're filing a bug report.
             ),
             AvailableCommand::new(
                 ":offline",
-                "Set offline mode when invoking cargo",
+                "Set offline mode when invoking cargo (0/1)",
                 |_ctx, state, args| {
                     state.set_offline_mode(args.as_ref().map(String::as_str) == Some("1"));
                     text_output(format!("Offline mode: {}", state.offline_mode()))


### PR DESCRIPTION
This makes it easier to discover the `:offline` command and hopefully makes it easier for users to work around issues with their internet connection.

No worries if you reject this pull request because checking for a specific error message is not a clean enough solution. Feedback is appreciated!