### PR TITLE
Add missing commands to COMMON.md

### DIFF
--- a/COMMON.md
+++ b/COMMON.md
@@ -180,22 +180,28 @@ $ sudo apt install lld
 
 Here is a complete list of the configuration options you can set to customize your Evcxr experience:
 
-* `:opt [level]`      Toggle/set optimization level
-* `:fmt [format]`     Set output formatter (default: `{:?}`). 
-* `:types`            Toggle printing of the type of the output
 * `:efmt [format]`    Set the formatter for errors returned by `?`
-* `:sccache [0|1]`    Set whether to use sccache.
-* `:linker [linker]`  Set/print linker. Supported: `system`, `lld`, `mold`
-* `:timing`           Toggle printing of how long evaluations take
-* `:time_passes`      Toggle printing of rustc pass times (requires nightly)
+* `:fmt [format]`     Set output formatter (default: `{:?}`)
 * `:internal_debug`   Toggle internal code debugging output
+* `:linker [linker]`  Set/print linker. Supported: `system`, `lld`, `mold`
+* `:offline [0|1]`    Set offline mode when invoking cargo
+* `:opt [level]`      Toggle/set optimization level
 * `:preserve_vars_on_panic [0|1]`  Try to keep vars on panic
+* `:sccache [0|1]`    Set whether to use sccache
+* `:time_passes`      Toggle printing of rustc pass times (requires nightly)
+* `:timing`           Toggle printing of how long evaluations take
+* `:toolchain`        Set which toolchain to use (e.g. nightly)
+* `:types`            Toggle printing of the type of the output
 
 And here are the supported Evcxr commands:
 
-* `:explain`          Print the explanation of last error
 * `:clear`            Clear all state, keeping compilation cache
+* `:dep`              Add an external dependency. e.g. `:dep regex = "1.0"`
+* `:explain`          Print the explanation of last error
+* `:help`             View the help message
 * `:last_compile_dir` Print the directory in which we last compiled
 * `:last_error_json`  Print the last compilation error as JSON (for debugging)
-* `:dep`              Add an external dependency. e.g. `:dep regex = "1.0"`
-* `:help`             View the help message
+* `:load_config`      Reloads startup configuration files. Accepts optional flag `--quiet` to suppress logging.
+* `:quit`             Quit evaluation and exit
+* `:vars`             List bound variables and their types
+* `:version`          Print Evcxr version


### PR DESCRIPTION
I have also changed the order of the commands to be alphabetical (not sure if there was previously any specific order).