### PR TITLE
Make :dep print info about compiled crates

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -620,7 +620,7 @@ Panic detected. Here's some useful information if you're filing a bug report.
             let out = format!("{args}: {out}");
             Ok(EvalOutputs::text_html(out.clone(), out))
         } else {
-            bail!(format!("Variable does not exist: {}", args))
+            bail!("Variable does not exist: {}", args)
         }
     }
 }


### PR DESCRIPTION
Closes #224 Obsoletes #267

When cargo compiles crates, the name of the crate is printed to stderr. Example output:

```
Welcome to evcxr. For help, type :help
>> :dep regex
   Compiling memchr v2.5.0
   Compiling regex v1.8.1
>>
```