### PR TITLE
Shorthand for importing local crates

### DIFF
--- a/COMMON.md
+++ b/COMMON.md
@@ -49,6 +49,14 @@ You can use the local work-in-progress crate like this:
 >> use my_crate::*;
 ```
 
+Alternatively you can use a shorter form:
+
+```rust
+>> :dep .
+>> :dep ../another_crate
+>> :dep /path/to/crate
+```
+
 It will even automatically update when you save your files!
 
 There are many other options that can be specified. See Cargo's [official dependency

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -238,7 +238,7 @@ checksum = "4df80a3fbc1f0e59f560eeeebca94bf655566a8ad3023c210a109deb6056455a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "synstructure",
 ]
 
@@ -671,7 +671,7 @@ checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
 dependencies = [
  "num-traits",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -733,6 +733,7 @@ dependencies = [
  "salsa",
  "sig",
  "tempfile",
+ "toml",
  "unicode-segmentation",
  "which",
 ]
@@ -921,7 +922,7 @@ checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1564,7 +1565,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "version_check",
 ]
 
@@ -1587,9 +1588,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1616,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2317,7 +2318,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2352,22 +2353,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2378,6 +2379,15 @@ checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
  "serde",
 ]
 
@@ -2477,7 +2487,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2498,6 +2508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,7 +2526,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "unicode-xid",
 ]
 
@@ -2555,7 +2576,7 @@ checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2621,7 +2642,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2637,6 +2658,40 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2659,7 +2714,7 @@ checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2948,6 +3003,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winnow"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5617da7e1f97bf363947d767b91aaf3c2bbc19db7fda9c65af1278713d58e0a2"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yansi"

--- a/evcxr/Cargo.toml
+++ b/evcxr/Cargo.toml
@@ -22,6 +22,7 @@ which = "4.0.2"
 evcxr_input = "1.0.0"
 unicode-segmentation = "1.7.1"
 crossbeam-channel = "0.5.5"
+toml = { version = "0.7.3", default-features = false, features = [ "parse" ] }
 
 ra_ap_ide = "=0.0.149"
 ra_ap_ide_db = "=0.0.149"

--- a/evcxr/src/cargo_metadata.rs
+++ b/evcxr/src/cargo_metadata.rs
@@ -155,13 +155,15 @@ pub fn parse_crate_names(path: &str) -> Result<(String, String)> {
         .parse::<toml::Table>()
         .context("Can't parse Cargo.toml")?;
 
-    if let Some(_workspace) = package.get("workspace") {
-        bail!("Workspaces are not supported");
-    } else if let Some(package) = package.get("package") {
+    // https://doc.rust-lang.org/cargo/reference/manifest.html
+    // The fields to define a package are 'package' and 'workspace'
+    if let Some(package) = package.get("package") {
         let package = prism!(Value::Table, package, "expected 'package' to be a table");
         let name = prism!(Some, package.get("name"), "no 'name' in package");
         let name = prism!(Value::String, name, "expected 'name' to be a string");
         Ok((name.clone(), path.to_owned()))
+    } else if let Some(_workspace) = package.get("workspace") {
+        bail!("Workspaces are not supported");
     } else {
         bail!("Unexpected Cargo.toml format: not package or workspace")
     }

--- a/evcxr/src/cargo_metadata.rs
+++ b/evcxr/src/cargo_metadata.rs
@@ -142,9 +142,8 @@ macro_rules! prism {
     };
 }
 
-/// Parse the crate at given path, producing crate name. If the path is a
-/// workspace of crates, will recurse into each.
-pub fn parse_crate_names(path: &str) -> Result<(String, String)> {
+/// Parse the crate at given path, producing crate name
+pub fn parse_crate_name(path: &str) -> Result<String> {
     use std::io::Read;
     use toml::Value;
 
@@ -161,7 +160,7 @@ pub fn parse_crate_names(path: &str) -> Result<(String, String)> {
         let package = prism!(Value::Table, package, "expected 'package' to be a table");
         let name = prism!(Some, package.get("name"), "no 'name' in package");
         let name = prism!(Value::String, name, "expected 'name' to be a string");
-        Ok((name.clone(), path.to_owned()))
+        Ok(name.clone())
     } else if let Some(_workspace) = package.get("workspace") {
         bail!("Workspaces are not supported");
     } else {

--- a/evcxr/src/cargo_metadata.rs
+++ b/evcxr/src/cargo_metadata.rs
@@ -144,12 +144,10 @@ macro_rules! prism {
 
 /// Parse the crate at given path, producing crate name
 pub fn parse_crate_name(path: &str) -> Result<String> {
-    use std::io::Read;
     use toml::Value;
 
-    let config_path = format!("{}/Cargo.toml", path);
-    let mut content = String::new();
-    std::fs::File::open(config_path)?.read_to_string(&mut content)?;
+    let config_path = std::path::Path::new(path).join("Cargo.toml");
+    let content = std::fs::read_to_string(config_path)?;
     let package = content
         .parse::<toml::Table>()
         .context("Can't parse Cargo.toml")?;

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -1213,8 +1213,8 @@ impl ContextState {
 
     /// Adds a crate dependency at the specified local path
     pub fn add_local_dep(&mut self, dep: &str) -> Result<(), Error> {
-        let (name, path) = cargo_metadata::parse_crate_names(dep)?;
-        self.add_dep(&name, &format!("{{ path = \"{}\" }}", path))
+        let name = cargo_metadata::parse_crate_name(dep)?;
+        self.add_dep(&name, &format!("{{ path = \"{}\" }}", dep))
     }
 
     /// Clears fields that aren't useful for inclusion in bug reports and which might give away

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -1213,11 +1213,8 @@ impl ContextState {
 
     /// Adds a crate dependency at the specified local path
     pub fn add_local_dep(&mut self, dep: &str) -> Result<(), Error> {
-        let names = cargo_metadata::parse_crate_names(dep)?;
-        for (name, path) in &names {
-            self.add_dep(name, &format!("{{ path = \"{}\" }}", path))?;
-        }
-        Ok(())
+        let (name, path) = cargo_metadata::parse_crate_names(dep)?;
+        self.add_dep(&name, &format!("{{ path = \"{}\" }}", path))
     }
 
     /// Clears fields that aren't useful for inclusion in bug reports and which might give away

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -5,6 +5,7 @@
 // or https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::cargo_metadata;
 use crate::child_process::ChildProcess;
 use crate::code_block::CodeBlock;
 use crate::code_block::CodeKind;
@@ -1210,6 +1211,15 @@ impl ContextState {
         Ok(())
     }
 
+    /// Adds a crate dependency at the specified local path
+    pub fn add_local_dep(&mut self, dep: &str) -> Result<(), Error> {
+        let names = cargo_metadata::parse_crate_names(dep)?;
+        for (name, path) in &names {
+            self.add_dep(name, &format!("{{ path = \"{}\" }}", path))?;
+        }
+        Ok(())
+    }
+
     /// Clears fields that aren't useful for inclusion in bug reports and which might give away
     /// things like usernames.
     pub(crate) fn clear_non_debug_relevant_fields(&mut self) {
@@ -1755,7 +1765,6 @@ impl ContextState {
     }
 
     fn dependency_lib_names(&self) -> Result<Vec<String>> {
-        use crate::cargo_metadata;
         cargo_metadata::get_library_names(&self.config)
     }
 

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -383,13 +383,15 @@ impl TmpCrate {
     }
 
     fn dep_command(&self, extra_options: &str) -> String {
-        format!(
-            ":dep {} = {{ path = \"{}\"{}{} }}",
-            self.name,
-            self.tempdir.path().to_string_lossy().replace('\\', "\\\\"),
-            if extra_options.is_empty() { "" } else { ", " },
-            extra_options
-        )
+        let path = self.tempdir.path().to_string_lossy().replace('\\', "\\\\");
+        if extra_options.is_empty() {
+            format!(":dep {}", path)
+        } else {
+            format!(
+                ":dep {} = {{ path = \"{}\", {} }}",
+                self.name, path, extra_options
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Allows running `:dep ./path` for adding crates by filesystem path.

To get crate name to add to dependencies, we parse the cargo.toml file at path. The format is very simple for packages, but not for workspaces, with globs and excludes, so I decided against it.

Both versions of the dep command are now tested in integration tests.

Feel free to squash the commits, as they represent a history of me deciding not to parse workspaces.