### PR TITLE
Allow extra command line arguments #297

### DIFF
--- a/evcxr/src/child_process.rs
+++ b/evcxr/src/child_process.rs
@@ -37,6 +37,7 @@ impl ChildProcess {
             bail!("Our current binary doesn't call runtime_hook()");
         }
         command
+            .arg("--foo")
             .env(runtime::EVCXR_IS_RUNTIME_VAR, "1")
             .env("RUST_BACKTRACE", "1")
             .stdin(std::process::Stdio::piped())

--- a/evcxr/src/child_process.rs
+++ b/evcxr/src/child_process.rs
@@ -37,7 +37,7 @@ impl ChildProcess {
             bail!("Our current binary doesn't call runtime_hook()");
         }
         command
-            .arg("--foo")
+            .args(std::env::args())
             .env(runtime::EVCXR_IS_RUNTIME_VAR, "1")
             .env("RUST_BACKTRACE", "1")
             .stdin(std::process::Stdio::piped())

--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -249,6 +249,10 @@ struct Options {
         default_value = "emacs"
      )]
     edit_mode: rustyline::EditMode,
+    /// Extra arguments; ignored, but show up in std::env::args()
+    #[structopt(long = "extra-args", multiple = true)]
+    _extra_args: Vec<String>,
+    
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
- Pass, per the maintainer’s suggestion, extra arguments to the child subprocess, so that they can be seen in the REPL.
- Add, for Rust newbies like me, a new command-line option to allow more command-line arguments:

```--extra-args <extra-args>...    Extra arguments; ignored, but show up in std::env::args()```

I am, by hypothesis, a Rust newbie, so review may be in order.  

## Testing

- `EVCXR_TMPDIR=$HOME/tmp/e1 cargo test -- --test-threads 1` passed on MacOS 12.6.2 21G320 on M1 Max, with the same two crash dialogs I got from main. 
- `target/debug/evcxr --opt 2 --edit-mode emacs --extra-args \\--foo bar baz` gave: 

`>> std::env::args()`

`Args { inner: ["/Users/flash/Documents/Code/external_code/evcxr/target/debug/evcxr", "target/debug/evcxr", "--opt", "2", "--edit-mode", "emacs", "--extra-args", "\\--foo", "bar", "baz"] }`