### PR TITLE
Main

### DIFF
--- a/evcxr/examples/example_hover.rs
+++ b/evcxr/examples/example_hover.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 The Evcxr Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE
+// or https://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use evcxr::CommandContext;
+use evcxr::Error;
+use evcxr::EvalContext;
+use evcxr::EvalContextOutputs;
+use std::collections::HashMap;
+
+#[track_caller]
+fn eval_and_unwrap(ctxt: &mut CommandContext, code: &str) -> HashMap<String, String> {
+    match ctxt.execute(code) {
+        Ok(output) => output.content_by_mime_type,
+        Err(err) => {
+            println!(
+                "======== last src ========\n{}==========================",
+                ctxt.last_source().unwrap()
+            );
+            match err {
+                Error::CompilationErrors(errors) => {
+                    for error in errors {
+                        println!("{}", error.rendered());
+                    }
+                }
+                other => println!("{}", other),
+            }
+
+            panic!("Unexpected compilation error. See above for details");
+        }
+    }
+}
+
+fn new_command_context_and_outputs() -> (CommandContext, EvalContextOutputs) {
+    let (eval_context, outputs) = EvalContext::new_for_testing();
+    let command_context = CommandContext::with_eval_context(eval_context);
+    (command_context, outputs)
+}
+
+fn main() -> Result<(), Error> {
+    let (mut e, _) = new_command_context_and_outputs();
+    eval_and_unwrap(&mut e, r#"let a: usize = 1;"#);
+    eval_and_unwrap(&mut e, r#"
+    ///this is my struct
+    struct MyStruct(usize);
+    "#);
+    println!("{}", eval_and_unwrap(&mut e, r#":doc MyStruct"#)["text/html"]);
+    println!("{}", eval_and_unwrap(&mut e, r#":doc let"#)["text/html"]);
+    println!("{}", eval_and_unwrap(&mut e, r#":doc std::fs::File::create"#)["text/html"]);
+    Ok(())
+}

--- a/evcxr/src/code_block.rs
+++ b/evcxr/src/code_block.rs
@@ -288,6 +288,16 @@ impl CodeBlock {
             .ok_or_else(|| anyhow!("Offset {} doesn't refer to user code", user_code_offset))
     }
 
+    ///In order to get the offset, I tryed to use the function `user_offset_to_output_offset`
+    /// It works fine in crate `evcxr`, but not in jupyter. In jupyter, the offset is set
+    /// to be the starting position of `![allow(unused_imports)]`. I can't figure out it.
+    pub(crate) fn user_offset_to_output_offset_for_hover(&self) -> Result<usize> {
+        let re = Regex::new(r#"EvcxrUserCodeError>"#).unwrap();
+        let code_str = self.code_string();
+        let res = re.find(&code_str).ok_or_else(|| anyhow!("Offset not found"))?;
+        Ok(res.end() + 3)
+    }
+
     pub(crate) fn output_offset_to_user_offset(&self, output_offset: usize) -> Result<usize> {
         let mut bytes_seen = 0;
         self.segments

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -32,9 +32,9 @@ use std::sync::Mutex;
 /// A higher level interface to EvalContext. A bit closer to a Repl. Provides commands (start with
 /// ':') that alter context state or print information.
 pub struct CommandContext {
-    pub print_timings: bool,
-    pub eval_context: EvalContext,
-    pub last_errors: Vec<CompilationError>,
+    print_timings: bool,
+    eval_context: EvalContext,
+    last_errors: Vec<CompilationError>,
 }
 
 impl CommandContext {

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -33,7 +33,7 @@ use std::sync::Mutex;
 /// ':') that alter context state or print information.
 pub struct CommandContext {
     print_timings: bool,
-    eval_context: EvalContext,
+    pub eval_context: EvalContext,
     last_errors: Vec<CompilationError>,
 }
 
@@ -569,6 +569,13 @@ Panic detected. Here's some useful information if you're filing a bug report.
                 writeln!(html, "</table>")?;
                 Ok(EvalOutputs::text_html(text, html))
             }),
+            AvailableCommand::new(
+                ":doc",
+                "show the docmentation of a variable, keysword, type or module",
+                |ctx, state, args| {
+                    ctx.hover(state, args)
+                }
+            )
         ]
     }
 
@@ -618,6 +625,16 @@ Panic detected. Here's some useful information if you're filing a bug report.
         } else {
             bail!("Variable does not exist: {}", args)
         }
+    }
+
+    fn hover(&mut self, state: &mut ContextState, args: &Option<String>) -> Result<EvalOutputs, Error> {
+        let args = if let Some(x) = args {
+            x.trim()
+        } else {
+            bail!("Input required")
+        };
+        let res = self.eval_context.hover(args, state)?;
+        Ok(EvalOutputs::text_html(res.clone(), res))
     }
 }
 

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -33,7 +33,7 @@ use std::sync::Mutex;
 /// ':') that alter context state or print information.
 pub struct CommandContext {
     print_timings: bool,
-    pub eval_context: EvalContext,
+    eval_context: EvalContext,
     last_errors: Vec<CompilationError>,
 }
 

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -32,8 +32,8 @@ use std::sync::Mutex;
 /// A higher level interface to EvalContext. A bit closer to a Repl. Provides commands (start with
 /// ':') that alter context state or print information.
 pub struct CommandContext {
-    print_timings: bool,
-    eval_context: EvalContext,
+    pub print_timings: bool,
+    pub eval_context: EvalContext,
     last_errors: Vec<CompilationError>,
 }
 

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -34,7 +34,7 @@ use std::sync::Mutex;
 pub struct CommandContext {
     pub print_timings: bool,
     pub eval_context: EvalContext,
-    last_errors: Vec<CompilationError>,
+    pub last_errors: Vec<CompilationError>,
 }
 
 impl CommandContext {

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -1065,3 +1065,17 @@ let s2 = "さび  äää"; let s2: String = 42; fn foo() -> i32 {
     // Dropped variables shouldn't report errors.
     assert_no_errors(&mut ctx, "let s1 = String::new(); std::mem::drop(s1);");
 }
+
+#[test]
+fn check_for_doc() {
+    let (mut e, _) = new_command_context_and_outputs();
+    eval_and_unwrap(&mut e, r#"
+    ///this is my struct
+    struct MyStruct(usize);
+    "#);
+    let res = eval_and_unwrap(&mut e, r#":doc MyStruct"#);
+    assert_eq!(
+        res.get("text/html"),
+        Some(&String::from("\n```rust\nctx\n```\n\n```rust\nstruct MyStruct\n```\n\n---\n\nthis is my struct")),
+    );
+}


### PR DESCRIPTION
Add a `context_command` `:doc` to show the documentation of a variable, type, keyword, module or function. For example `:doc i32` 