### PR TITLE
Make the error less mysterious when `rust_analyzer` can't determin the variable type.

### DIFF
--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -441,23 +441,24 @@ impl EvalContext {
         let mut phases = PhaseDetailsBuilder::new();
         let code_out = state.apply(user_code.clone(), &code_info.nodes)?;
 
-        let mut outputs = match self.run_statements(code_out, code_info, &mut state, &mut phases, callbacks) {
-            error @ Err(Error::SubprocessTerminated(_)) => {
-                self.restart_child_process()?;
-                return error;
-            }
-            Err(Error::CompilationErrors(errors)) => {
-                let mut errors = state.apply_custom_errors(errors, &user_code, code_info);
-                // If we have any errors in user code then remove all errors that aren't from user
-                // code.
-                if errors.iter().any(|error| error.is_from_user_code()) {
-                    errors.retain(|error| error.is_from_user_code())
+        let mut outputs =
+            match self.run_statements(code_out, code_info, &mut state, &mut phases, callbacks) {
+                error @ Err(Error::SubprocessTerminated(_)) => {
+                    self.restart_child_process()?;
+                    return error;
                 }
-                return Err(Error::CompilationErrors(errors));
-            }
-            error @ Err(_) => return error,
-            Ok(x) => x,
-        };
+                Err(Error::CompilationErrors(errors)) => {
+                    let mut errors = state.apply_custom_errors(errors, &user_code, code_info);
+                    // If we have any errors in user code then remove all errors that aren't from user
+                    // code.
+                    if errors.iter().any(|error| error.is_from_user_code()) {
+                        errors.retain(|error| error.is_from_user_code())
+                    }
+                    return Err(Error::CompilationErrors(errors));
+                }
+                error @ Err(_) => return error,
+                Ok(x) => x,
+            };
 
         // Once, we reach here, our code has successfully executed, so we
         // conclude that variable changes are now applied.
@@ -512,7 +513,7 @@ impl EvalContext {
         let (modified_code, hover_offset) = if code == "let" {
             (String::from("let _ = 1;"), 0)
         } else if code.ends_with('(') {
-            //If code is a function like `Option::ok_or_else`, the hover works fine, but if it is 
+            //If code is a function like `Option::ok_or_else`, the hover works fine, but if it is
             // method like `None.ok_or_else`, the hover show nothing, in order to show that, the code
             // has to end with "(", like `None.ok_or_else(`
             (format!("{});", code), code.len() - 1)
@@ -629,9 +630,9 @@ impl EvalContext {
         if let Err(errors) = self.fix_variable_types(state, analysis_code) {
             let check_res = self.check(user_code.clone(), state.clone(), code_info)?;
             if check_res.is_empty() {
-                return Err(errors)
+                return Err(errors);
             }
-            return Err(Error::CompilationErrors(check_res))
+            return Err(Error::CompilationErrors(check_res));
         }
         // In some circumstances we may need a few tries before we get the code right. Note that
         // we'll generally give up sooner than this if there's nothing left that we think we can


### PR DESCRIPTION
When the input is like:
```
let a = undefined_function(1);
```
the error show needing of type anotation, but it is more direct if the error show that then function `undefined_function` is not defined.
I add code to call `check` after `fix_variable_types`, it works fine in crate `evcxr`, but in jupyter, if the input is the above example and include `evcxr.init` and `prelude.rs`(as like https://github.com/evcxr/evcxr/pull/323#discussion_r1322282512), the cell will run forever(never teminate). If I remove `evcxr.init` and `prelude.rs`, then it works fine. I thought it may be a problem related to `commit_old_user_code`, but I can't figure it out.