### PR TITLE
Add option to set the initializing config from the current working directory.

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -226,14 +226,22 @@ Panic detected. Here's some useful information if you're filing a bug report.
         Ok(completions)
     }
 
-    fn load_config(&mut self, _quiet: bool) -> Result<EvalOutputs, Error> {
+    fn load_config(&mut self, quiet: bool) -> Result<EvalOutputs, Error> {
         let mut outputs = EvalOutputs::new();
         let init_config = InitConfig::parse_as_one_step()?;
-        if let Some(init) = init_config.init {
-            outputs.merge(self.execute(&init)?);
+        if let Some(init_path) = init_config.init {
+            if !quiet {
+                println!("Loading startup commands from {init_path:?}");
+            }
+            let init_content = std::fs::read_to_string(init_path)?;
+            outputs.merge(self.execute(&init_content)?);
         }
-        if let Some(prelude) = init_config.prelude {
-            outputs.merge(self.execute(&prelude)?);
+        if let Some(prelude_path) = init_config.prelude {
+            if !quiet {
+                println!("Executing prelude from {prelude_path:?}");
+            }
+            let prelude_content = std::fs::read_to_string(prelude_path)?;
+            outputs.merge(self.execute(&prelude_content)?);
         }
         Ok(outputs)
     }

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -112,18 +112,17 @@ pub(crate) struct InitConfig {
 impl InitConfig {
     pub(crate) fn check_if_exists(path: &Path) -> bool {
         if !path.is_dir() {
-            return false
+            return false;
         }
-        path
-            .read_dir()
-            .map_or_else(
-                |_| false,
-                |mut dir| {
-                    dir
-                        .position(|entry| entry.map_or_else(|_| false, |x| x.file_name() == "init.evcxr"))
-                        .map_or_else(|| false, |_| true)
-                }
-            )
+        path.read_dir().map_or_else(
+            |_| false,
+            |mut dir| {
+                dir.position(|entry| {
+                    entry.map_or_else(|_| false, |x| x.file_name() == "init.evcxr")
+                })
+                .map_or_else(|| false, |_| true)
+            },
+        )
     }
 
     pub(crate) fn parse_from_path(path: &Path) -> Result<Self, Error> {
@@ -141,16 +140,16 @@ impl InitConfig {
                         res.init = String::default().into();
                     }
                     "prelude" => {
-                        res.prelude =String::default().into();
+                        res.prelude = String::default().into();
                     }
                     _ => {
                         bail!("attribute {} not implemented", last_config_attr);
                     }
                 }
-                continue
+                continue;
             }
             if last_config_attr.is_empty() {
-                continue
+                continue;
             }
             match last_config_attr.as_str() {
                 "tmpdir" => {


### PR DESCRIPTION
There is a discussion in [there](https://github.com/evcxr/evcxr/discussions/345).
This pr add an option to set the initializing config from the current diretory where the notebook is ready to lanuch. The config file looks like this:
```rust
[tmpdir]
tmpdir

[init]
:dep chrono = "*"

[prelude]
use chrono::NaiveDateTime as dt;
```
The attribute `tmpdir` points to the directory where the code will be compiled into, and the attribute `init` is the content that should be in  `init.evcxr`  before, and the attribute `prelude` is the content that should be in `prelude.rs` before.
This configuration file should be located in the current directory, and be named `init.evcxr`. When  `evcxr` is starts, it will check if the current directory contains the file `init.evcxr`. If not, next it will check if `crate::config_dir` contains the file `init.evcxr`. If not, it will load not anything the conmmand `:load_config` is executed. 
After loading the configuration, if it contains the attribute `tmpdir`, `evcxr` will use this `tmpdir` as  temprory compiling directory. If not, `evcxr` will check if there is an environmental variale `EVCXR_TMPDIR`.