### PR TITLE
Block until stdout_sender is empty with exponential backoff

### DIFF
--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -950,6 +950,14 @@ impl EvalContext {
         } else if !lost_variables.is_empty() {
             return Err(Error::TypeRedefinedVariablesLost(lost_variables));
         }
+
+        // Block until stdout_sender is empty with exponential backoff
+        let mut sleep_duration = Duration::from_millis(1);
+        while !self.stdout_sender.is_empty() {
+            std::thread::sleep(sleep_duration);
+            sleep_duration = std::cmp::min(sleep_duration * 2, Duration::from_millis(100));
+        }
+
         Ok(output)
     }
 

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -217,16 +217,21 @@ fn missing_semicolon_on_let_stmt() {
 fn printing() {
     let (mut e, outputs) = new_command_context_and_outputs();
 
-    eval!(e,
-        println!("This is stdout");
-        eprintln!("This is stderr");
-        println!("Another stdout line");
-        eprintln!("Another stderr line");
-    );
+    let handle = std::thread::spawn(move || {
+        eval!(e,
+            println!("This is stdout");
+            eprintln!("This is stderr");
+            println!("Another stdout line");
+            eprintln!("Another stderr line");
+        );
+    });
+
     assert_eq!(outputs.stdout.recv(), Ok("This is stdout".to_owned()));
     assert_eq!(outputs.stderr.recv(), Ok("This is stderr".to_owned()));
     assert_eq!(outputs.stdout.recv(), Ok("Another stdout line".to_owned()));
     assert_eq!(outputs.stderr.recv(), Ok("Another stderr line".to_owned()));
+
+    handle.join().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This is the fix discussed in #353.

As I mentioned there, I tested this with 100 test runs and it seems to fix the issue. But, I'm not familiar enough with the workings here to be sure this will work in all circumstances. For example, a) background threads continuing to write to stdout and b) possible concurrent use of `stdout_sender` between different Jupyter requests.