### PR TITLE
Use .display() for :last_compile_dir

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -477,7 +477,7 @@ Panic detected. Here's some useful information if you're filing a bug report.
                 ":last_compile_dir",
                 "Print the directory in which we last compiled",
                 |ctx, _state, _args| {
-                    text_output(format!("{:?}", ctx.eval_context.last_compile_dir()))
+                    text_output(format!("{}", ctx.eval_context.last_compile_dir().display()))
                 },
             ),
             AvailableCommand::new(


### PR DESCRIPTION
`:last_compile_dir` currently uses `Debug` implementation for `Path` which replaces each backslash `\` with `\\`  for Windows paths. This makes it inconvenient as one needs to replace them back to navigate to such path. Instead we can use [`Path::display`](https://doc.rust-lang.org/std/path/struct.Path.html#method.display) method to properly display paths. VSCode now turns it into a hyperlink and offers to open it in VSCode if you click on it which is very useful.

Before:
<img width="469" height="91" alt="before" src="https://github.com/user-attachments/assets/dc2a95f5-63c7-4e90-bece-2709d04d8601" />

After:
<img width="435" height="95" alt="after" src="https://github.com/user-attachments/assets/8c7e5f00-c5a3-44bc-b469-94f66fd6c709" />
