### PR TITLE
Add tools that supports evcxr jupyter

### DIFF
--- a/evcxr_jupyter/README.md
+++ b/evcxr_jupyter/README.md
@@ -131,9 +131,9 @@ cargo install --force --git https://github.com/evcxr/evcxr.git evcxr_jupyter
 
 There are several Rust crates that provide Evcxr integration:
 
-*[Charton](https://github.com/wangjiawen2013/charton).
+* [Charton](https://github.com/wangjiawen2013/charton).
   * Display charts
-*[Plotpy](https://github.com/cpmech/plotpy).
+* [Plotpy](https://github.com/cpmech/plotpy).
   * Show figures
 * [Petgraph](https://crates.io/crates/petgraph-evcxr)
   * Graphs (the kind with nodes and edges)


### PR DESCRIPTION
Charton and plotpy are plotting tools for Rust that support evcxr jupyter natively.