### PR TITLE
Add :features command for notebook crate (#376)

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -537,6 +537,34 @@ Panic detected. Here's some useful information if you're filing a bug report.
                 },
             ),
             AvailableCommand::new(
+                ":features",
+                "Set/clear features for the generated crate. e.g. :features foo,bar",
+                |_ctx, state, args| {
+                    match args.as_deref() {
+                        // No argument: print current features.
+                        None => {
+                            let current = state.features().join(", ");
+                            text_output(format!("features: {current}"))
+                        }
+                        // Empty string (":features " with trailing space): clear features.
+                        Some("") => {
+                            state.set_features(vec![]);
+                            text_output("features: (none)")
+                        }
+                        // Comma-separated list: replace feature set.
+                        Some(list) => {
+                            let features: Vec<String> = list
+                                .split(',')
+                                .map(|s| s.trim().to_owned())
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                            state.set_features(features.clone());
+                            text_output(format!("features: {}", features.join(", ")))
+                        }
+                    }
+                },
+            ),
+            AvailableCommand::new(
                 ":offline",
                 "Set offline mode when invoking cargo (0/1)",
                 |_ctx, state, args| {

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -541,26 +541,21 @@ Panic detected. Here's some useful information if you're filing a bug report.
                 "Set/clear features for the generated crate. e.g. :features foo,bar",
                 |_ctx, state, args| {
                     match args.as_deref() {
-                        // No argument: print current features.
-                        None => {
-                            let current = state.features().join(", ");
-                            text_output(format!("features: {current}"))
-                        }
-                        // Empty string (":features " with trailing space): clear features.
-                        Some("") => {
-                            state.set_features(vec![]);
-                            text_output("features: (none)")
-                        }
-                        // Comma-separated list: replace feature set.
+                        None => {}
                         Some(list) => {
                             let features: Vec<String> = list
                                 .split(',')
                                 .map(|s| s.trim().to_owned())
                                 .filter(|s| !s.is_empty())
                                 .collect();
-                            state.set_features(features.clone());
-                            text_output(format!("features: {}", features.join(", ")))
+                            state.set_features(features);
                         }
+                    }
+                    let current = state.features().join(", ");
+                    if current.is_empty() {
+                        text_output("features: (none)")
+                    } else {
+                        text_output(format!("features: {current}"))
                     }
                 },
             ),

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -102,6 +102,8 @@ pub(crate) struct Config {
     pub(crate) allow_static_linking: bool,
     pub(crate) build_envs: HashMap<String, String>,
     subprocess_path: PathBuf,
+    /// Features to declare in the generated crate's [features] section.
+    pub(crate) features: Vec<String>,
 }
 
 fn create_initial_config(tmpdir: PathBuf, subprocess_path: PathBuf) -> Result<Config> {
@@ -148,6 +150,7 @@ impl Config {
             subprocess_path,
             codegen_backend: None,
             build_envs: Default::default(),
+            features: Vec::new(),
         })
     }
 
@@ -1380,6 +1383,14 @@ impl ContextState {
 
     pub fn toolchain(&mut self) -> &str {
         &self.config.toolchain
+    }
+
+    pub fn features(&self) -> &[String] {
+        &self.config.features
+    }
+
+    pub fn set_features(&mut self, features: Vec<String>) {
+        self.config.features = features;
     }
 
     /// Adds a crate dependency with the specified name and configuration.

--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -242,6 +242,20 @@ impl Module {
 
     fn get_cargo_toml_contents(&self, state: &ContextState) -> String {
         let crate_imports = state.format_cargo_deps();
+        let features = state.features();
+        // Only emit [features] when the user has actually declared some; otherwise the generated
+        // Cargo.toml is identical to what it was before this feature was added.
+        let features_section = if features.is_empty() {
+            String::new()
+        } else {
+            let feature_lines: String = features.iter().map(|f| format!("{f} = []\n")).collect();
+            let default_list = features
+                .iter()
+                .map(|f| format!("\"{f}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("\n[features]\ndefault = [{default_list}]\n{feature_lines}")
+        };
         format!(
             r#"
 [package]
@@ -266,11 +280,12 @@ incremental = true
 overflow-checks = true
 
 [dependencies]
-{}
+{}{}
 "#,
             CRATE_NAME,
             state.opt_level(),
-            crate_imports
+            crate_imports,
+            features_section
         )
     }
 

--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -243,8 +243,6 @@ impl Module {
     fn get_cargo_toml_contents(&self, state: &ContextState) -> String {
         let crate_imports = state.format_cargo_deps();
         let features = state.features();
-        // Only emit [features] when the user has actually declared some; otherwise the generated
-        // Cargo.toml is identical to what it was before this feature was added.
         let features_section = if features.is_empty() {
             String::new()
         } else {


### PR DESCRIPTION
## Summary

- Adds a `:features` command that lets users declare features on the generated evaluation crate, so `cfg(feature = "foo")` gating works in notebook code.
- Plumbs a `Vec<String>` through `Config` / `ContextState` into `get_cargo_toml_contents` in `module.rs`, emitting a `[features]` section with all declared features listed in `default` (so they activate without any explicit `--features` flag).
- The `[features]` section is omitted entirely when the list is empty — no behaviour change for existing users.

Implementation follows the sketch in #376:
> declare features in the generated Cargo.toml … plumb a Vec<String> through ContextState, modify get_cargo_toml_contents … add a :features foo,bar command

## Usage

```
:features foo,bar     # set features (replaces previous list)
:features             # print currently enabled features
:features             # (with trailing space / empty arg) clears all features
```

## Test plan

- [ ] Start the REPL or a Jupyter kernel.
- [ ] Run `:features myfeat` then evaluate `cfg!(feature = "myfeat")` — should print `true`.
- [ ] Run `:features` (no args) — should print `features: myfeat`.
- [ ] Run `:features ` (empty arg) — should print `features: (none)`.
- [ ] Evaluate `cfg!(feature = "myfeat")` again — should now print `false`.
- [ ] Verify that a session that never calls `:features` produces the same Cargo.toml as before (no `[features]` section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)