### PR TITLE
Add :patch command for [patch.crates-io] entries (#370)

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -474,6 +474,11 @@ Panic detected. Here's some useful information if you're filing a bug report.
                 |_ctx, state, _args| process_show_deps_command(state),
             ),
             AvailableCommand::new(
+                ":patch",
+                "Add a [patch.crates-io] entry. e.g. :patch some-crate = { path = \"/path\" }",
+                |_ctx, state, args| process_patch_command(state, args),
+            ),
+            AvailableCommand::new(
                 ":last_compile_dir",
                 "Print the directory in which we last compiled",
                 |ctx, _state, _args| {
@@ -812,6 +817,32 @@ fn process_dep_command(
         Ok(EvalOutputs::new())
     } else {
         bail!("Invalid :dep command. Expected: name = ... or just name");
+    }
+}
+
+fn process_patch_command(
+    state: &mut ContextState,
+    args: &Option<String>,
+) -> Result<EvalOutputs, Error> {
+    use regex::Regex;
+    let Some(args) = args else {
+        let patches = &state.crates_io_patches;
+        if patches.is_empty() {
+            return text_output("[patch.crates-io]: (none)");
+        }
+        let mut lines: Vec<String> = patches
+            .iter()
+            .map(|(name, cfg)| format!("{name} = {cfg}"))
+            .collect();
+        lines.sort();
+        return text_output(lines.join("\n"));
+    };
+    static PATCH_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^([^= ]+) *= *(.+)$").unwrap());
+    if let Some(captures) = PATCH_RE.captures(args) {
+        state.add_crates_io_patch(captures[1].to_owned(), captures[2].trim().to_owned());
+        Ok(EvalOutputs::new())
+    } else {
+        bail!("Invalid :patch command. Expected: crate-name = {{ ... }}");
     }
 }
 

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -1217,6 +1217,8 @@ pub struct ContextState {
     allow_question_mark: bool,
     build_num: i32,
     pub(crate) config: Config,
+    /// [patch.crates-io] entries: crate name → TOML config string.
+    pub(crate) crates_io_patches: HashMap<String, String>,
 }
 
 impl ContextState {
@@ -1233,6 +1235,7 @@ impl ContextState {
             allow_question_mark: false,
             build_num: 0,
             config,
+            crates_io_patches: HashMap::new(),
         }
     }
 
@@ -1503,6 +1506,23 @@ impl ContextState {
             .map(|krate| format!("{} = {}\n", krate.name, krate.config))
             .collect::<Vec<_>>()
             .join("")
+    }
+
+    pub(crate) fn format_cargo_patches(&self) -> String {
+        if self.crates_io_patches.is_empty() {
+            return String::new();
+        }
+        let mut entries: Vec<String> = self
+            .crates_io_patches
+            .iter()
+            .map(|(name, cfg)| format!("{name} = {cfg}"))
+            .collect();
+        entries.sort();
+        format!("\n[patch.crates-io]\n{}\n", entries.join("\n"))
+    }
+
+    pub fn add_crates_io_patch(&mut self, name: String, config: String) {
+        self.crates_io_patches.insert(name, config);
     }
 
     fn compilation_mode(&self) -> CompilationMode {

--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -242,6 +242,7 @@ impl Module {
 
     fn get_cargo_toml_contents(&self, state: &ContextState) -> String {
         let crate_imports = state.format_cargo_deps();
+        let patches = state.format_cargo_patches();
         format!(
             r#"
 [package]
@@ -266,11 +267,12 @@ incremental = true
 overflow-checks = true
 
 [dependencies]
-{}
+{}{}
 "#,
             CRATE_NAME,
             state.opt_level(),
-            crate_imports
+            crate_imports,
+            patches
         )
     }
 


### PR DESCRIPTION
Fixes #370.

Patches in a user's crate's `Cargo.toml` have no effect in evcxr because evcxr generates its own `Cargo.toml` for compilation. This adds a `:patch` command so users can add `[patch.crates-io]` entries to the generated Cargo.toml.

**Usage:**
```
# Add a patch
:patch some-crate = { git = "https://github.com/me/some-crate", rev = "abc123" }
:patch some-crate = { path = "/local/path/to/fork" }

# Show current patches
:patch
```

**Implementation:**
- `ContextState.crates_io_patches: HashMap<String, String>` stores entries
- `format_cargo_patches()` emits the `[patch.crates-io]` section (empty if no patches)
- `get_cargo_toml_contents` in `module.rs` appends the patch section
- `:patch` command in `command_context.rs` mirrors the `:dep` pattern

## Test plan
- `:dep` a crate that has a patched transitive dependency
- `:patch patched-crate = { path = "..." }` with a local fork
- Verify compilation uses the patched version