### PR TITLE
Enable tab completion for :doc arguments (#374)

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -228,6 +228,22 @@ Panic detected. Here's some useful information if you're filing a bug report.
     pub fn completions(&mut self, src: &str, position: usize) -> Result<Completions> {
         let (user_code, code_info) = CodeBlock::from_original_user_code(src);
         if let Some((segment, offset)) = user_code.command_containing_user_offset(position) {
+            // When the cursor is in the argument of :doc, delegate to rust-analyzer so
+            // type and module paths can be completed, not just command names.
+            let existing = segment.code[..offset].to_owned();
+            if let Some(arg_prefix) = existing.strip_prefix(":doc ") {
+                let arg_prefix = arg_prefix.to_owned();
+                let arg_len = arg_prefix.len();
+                let arg_start_in_src = position - arg_len;
+                let (arg_code, arg_info) = CodeBlock::from_original_user_code(&arg_prefix);
+                let (_, state, _) = self.prepare_for_analysis(arg_code.clone())?;
+                let mut completions =
+                    self.eval_context
+                        .completions(arg_code, state, &arg_info.nodes, arg_len)?;
+                completions.start_offset += arg_start_in_src;
+                completions.end_offset += arg_start_in_src;
+                return Ok(completions);
+            }
             return self.command_completions(segment, offset, position);
         }
         let (non_command_code, state, _errors) = self.prepare_for_analysis(user_code)?;


### PR DESCRIPTION
Fixes #374.

Previously `:doc i3<TAB>` produced no completions because `command_completions` only matches command names, not their arguments.

**Fix:** In `CommandContext::completions`, when the cursor is in the argument position of a `:doc` command, we extract the argument prefix and ask rust-analyzer for completions on it. The returned offsets are adjusted to map back to positions in the original source string.

**Example (REPL):**
```
>> :doc i3<TAB>        → :doc i32
>> :doc i32::ab<TAB>   → :doc i32::abs
```

## Test plan
- Build and start `evcxr`
- Type `:doc i3` and press Tab — verify it completes to `:doc i32`
- Type `:doc i32::ab` and press Tab — verify it completes to `:doc i32::abs`
- Verify regular command name completion (`:d<TAB>` → `:dep`, `:doc`, etc.) still works