### PR TITLE
Show compiler warnings in REPL (#238)

### DIFF
--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -806,7 +806,8 @@ impl EvalContext {
         }
         phases.phase_complete("Final compile");
 
-        let output = self.run_and_capture_output(state, &so_file, callbacks)?;
+        let mut output = self.run_and_capture_output(state, &so_file, callbacks)?;
+        output.warnings = so_file.warnings;
         Ok(ExecutionArtifacts { output })
     }
 
@@ -1117,6 +1118,7 @@ pub struct EvalOutputs {
     pub content_by_mime_type: HashMap<String, String>,
     pub timing: Option<Duration>,
     pub phases: Vec<PhaseDetails>,
+    pub warnings: Vec<CompilationError>,
 }
 
 impl EvalOutputs {
@@ -1125,6 +1127,7 @@ impl EvalOutputs {
             content_by_mime_type: HashMap::new(),
             timing: None,
             phases: Vec::new(),
+            warnings: Vec::new(),
         }
     }
 
@@ -1157,6 +1160,7 @@ impl EvalOutputs {
             (t1, t2) => t1.or(t2),
         };
         self.phases.append(&mut other.phases);
+        self.warnings.append(&mut other.warnings);
     }
 }
 

--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -196,6 +196,7 @@ impl Module {
             let output = String::from_utf8_lossy(&cargo_output.stderr);
             eprintln!("{output}");
         }
+        let warnings = warnings_from_cargo_output(&cargo_output, code_block);
         self.build_num += 1;
         let copied_so_file = config
             .deps_dir()
@@ -213,6 +214,7 @@ impl Module {
         rename_or_copy_so_file(&self.so_path(config), &copied_so_file)?;
         Ok(SoFile {
             path: copied_so_file,
+            warnings,
         })
     }
 
@@ -496,6 +498,35 @@ fn run_cargo(
     }
 }
 
+fn warnings_from_cargo_output(
+    cargo_output: &std::process::Output,
+    code_block: &CodeBlock,
+) -> Vec<CompilationError> {
+    let stderr = String::from_utf8_lossy(&cargo_output.stderr);
+    let stdout = String::from_utf8_lossy(&cargo_output.stdout);
+    stderr
+        .lines()
+        .chain(stdout.lines())
+        .filter_map(|line| {
+            let json = json::parse(line).ok()?;
+            let msg = if json["message"].is_object() {
+                &json["message"]
+            } else {
+                &json
+            };
+            if msg["level"].as_str() != Some("warning") {
+                return None;
+            }
+            let warning = CompilationError::opt_new(json, code_block)?;
+            if warning.is_from_user_code() {
+                Some(warning)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Process one line from cargo, either copying it to stderr or ignoring.
 ///
 /// At this point it looks for messages about compiling dependency crates.
@@ -547,4 +578,5 @@ fn errors_from_cargo_output(
 
 pub(crate) struct SoFile {
     pub(crate) path: PathBuf,
+    pub(crate) warnings: Vec<CompilationError>,
 }

--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -97,7 +97,11 @@ impl Repl {
             Err(error) => return Err(error.clone()),
         };
         let success = match execution_result {
-            Ok(output) => {
+            Ok(mut output) => {
+                let warnings = std::mem::take(&mut output.warnings);
+                if !warnings.is_empty() {
+                    self.display_errors(to_run, warnings);
+                }
                 if let Some(text) = output.get("text/plain") {
                     println!("{text}");
                 }
@@ -133,6 +137,15 @@ impl Repl {
     fn display_errors(&mut self, source: &str, errors: Vec<CompilationError>) {
         let mut last_span_lines: &Vec<String> = &vec![];
         for error in &errors {
+            if error.level() == "warning" {
+                let rendered = error.rendered();
+                if !rendered.is_empty() {
+                    println!("{rendered}");
+                } else {
+                    println!("{}", error.message().bright_yellow());
+                }
+                continue;
+            }
             if error.is_from_user_code() {
                 if let Some(report) =
                     error.build_report("command".to_string(), source.to_string(), Theme::Dark)


### PR DESCRIPTION
## Summary

- Rustc warnings from user code are now shown in the REPL after a successful compile, matching the behaviour already present in the Jupyter kernel.
- On a successful build, `warnings_from_cargo_output` parses warning-level JSON messages (user-code only) from the cargo output and attaches them to the new `EvalOutputs.warnings` field.
- The REPL frontend prints each warning using rustc's pre-formatted `rendered` string, which carries the correct yellow `warning:` prefix and source context.

Fixes #238. Jupyter behaviour is unchanged.

## Test plan

- [ ] Start the REPL and run `fn foo() { let mut s = String::new(); }` — expect an `unused variable` warning to be printed immediately after the successful compilation.
- [ ] Run `let _x = 1;` — expect no warning (underscore-prefixed variables suppress warnings).
- [ ] Run code that has a compile error — expect unchanged error display, no regressions.
- [ ] Run code with no warnings — expect clean output as before.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)