### PR TITLE
Feat/lsp-rich-completions

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -275,8 +275,6 @@ Panic detected. Here's some useful information if you're filing a bug report.
                     code: (*cmd).to_owned(),
                     kind: "magic",
                     label: (*cmd).to_owned(),
-                    detail: None,
-                    documentation: None,
                 })
             }
         }

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -273,6 +273,9 @@ Panic detected. Here's some useful information if you're filing a bug report.
             if cmd.starts_with(existing) {
                 completions.completions.push(Completion {
                     code: (*cmd).to_owned(),
+                    label: (*cmd).to_owned(),
+                    detail: None,
+                    documentation: None,
                 })
             }
         }

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -273,6 +273,7 @@ Panic detected. Here's some useful information if you're filing a bug report.
             if cmd.starts_with(existing) {
                 completions.completions.push(Completion {
                     code: (*cmd).to_owned(),
+                    kind: "magic",
                     label: (*cmd).to_owned(),
                     detail: None,
                     documentation: None,

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -776,6 +776,19 @@ Panic detected. Here's some useful information if you're filing a bug report.
         }
     }
 
+    /// Returns `(plain_text, html)` hover information for the expression at the end of `src`.
+    /// The position should be a byte offset. Uses accumulated REPL state so that previously
+    /// defined variables and imports are visible during hover analysis.
+    pub fn hover_at(&mut self, src: &str, position: usize) -> Result<(String, String)> {
+        let code_up_to_cursor = &src[..position];
+        let (user_code, _code_info) = CodeBlock::from_original_user_code(src);
+        let (_, mut state, _) = self.prepare_for_analysis(user_code)?;
+        let (plain, markdown) = self.eval_context.hover(code_up_to_cursor, &mut state)?;
+        let mut html = String::new();
+        pulldown_cmark::html::push_html(&mut html, pulldown_cmark::Parser::new(&markdown));
+        Ok((plain, html))
+    }
+
     fn hover(
         &mut self,
         state: &mut ContextState,

--- a/evcxr/src/rust_analyzer.rs
+++ b/evcxr/src/rust_analyzer.rs
@@ -345,6 +345,9 @@ impl RustAnalyzer {
                         code: ARG_PLACEHOLDER
                             .replace_all(&indel.insert, "$1")
                             .replace("$0", ""),
+                        label: item.label.primary.to_string(),
+                        detail: item.detail.clone(),
+                        documentation: item.documentation.as_ref().map(|d| d.as_str().to_owned()),
                     });
                     if let Some(previous_range) = range.as_ref() {
                         if *previous_range != indel.delete {
@@ -477,6 +480,9 @@ pub struct Completions {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Completion {
     pub code: String,
+    pub label: String,
+    pub detail: Option<String>,
+    pub documentation: Option<String>,
 }
 
 /// Returns whether this appears to be a valid type. Rust analyzer, when asked to emit code for some

--- a/evcxr/src/rust_analyzer.rs
+++ b/evcxr/src/rust_analyzer.rs
@@ -347,8 +347,6 @@ impl RustAnalyzer {
                             .replace("$0", ""),
                         kind: jupyter_kind(item.kind),
                         label: item.label.primary.to_string(),
-                        detail: item.detail.clone(),
-                        documentation: item.documentation.as_ref().map(|d| d.as_str().to_owned()),
                     });
                     if let Some(previous_range) = range.as_ref() {
                         if *previous_range != indel.delete {
@@ -483,8 +481,6 @@ pub struct Completion {
     pub code: String,
     pub kind: &'static str,
     pub label: String,
-    pub detail: Option<String>,
-    pub documentation: Option<String>,
 }
 
 fn jupyter_kind(kind: ra_ide::CompletionItemKind) -> &'static str {

--- a/evcxr/src/rust_analyzer.rs
+++ b/evcxr/src/rust_analyzer.rs
@@ -345,6 +345,7 @@ impl RustAnalyzer {
                         code: ARG_PLACEHOLDER
                             .replace_all(&indel.insert, "$1")
                             .replace("$0", ""),
+                        kind: jupyter_kind(item.kind),
                         label: item.label.primary.to_string(),
                         detail: item.detail.clone(),
                         documentation: item.documentation.as_ref().map(|d| d.as_str().to_owned()),
@@ -480,9 +481,54 @@ pub struct Completions {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Completion {
     pub code: String,
+    pub kind: &'static str,
     pub label: String,
     pub detail: Option<String>,
     pub documentation: Option<String>,
+}
+
+fn jupyter_kind(kind: ra_ide::CompletionItemKind) -> &'static str {
+    use ra_ap_ide_db::SymbolKind;
+    use ra_ide::CompletionItemKind as K;
+    match kind {
+        K::SymbolKind(SymbolKind::Function | SymbolKind::Method) => "function",
+        K::SymbolKind(
+            SymbolKind::Struct
+            | SymbolKind::Enum
+            | SymbolKind::Union
+            | SymbolKind::Trait
+            | SymbolKind::TypeAlias
+            | SymbolKind::TypeParam
+            | SymbolKind::SelfType,
+        ) => "class",
+        K::SymbolKind(SymbolKind::Module | SymbolKind::CrateRoot | SymbolKind::ToolModule) => {
+            "module"
+        }
+        K::SymbolKind(
+            SymbolKind::Const
+            | SymbolKind::Static
+            | SymbolKind::ConstParam
+            | SymbolKind::Variant
+            | SymbolKind::Field
+            | SymbolKind::Local
+            | SymbolKind::SelfParam
+            | SymbolKind::ValueParam
+            | SymbolKind::Label,
+        )
+        | K::Binding
+        | K::InferredType => "instance",
+        K::SymbolKind(
+            SymbolKind::Macro
+            | SymbolKind::ProcMacro
+            | SymbolKind::Derive
+            | SymbolKind::DeriveHelper
+            | SymbolKind::Attribute
+            | SymbolKind::BuiltinAttr,
+        ) => "function",
+        K::Keyword => "keyword",
+        K::Snippet | K::BuiltinType | K::UnresolvedReference | K::Expression => "instance",
+        _ => "instance",
+    }
 }
 
 /// Returns whether this appears to be a valid type. Rust analyzer, when asked to emit code for some

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -1180,21 +1180,11 @@ fn completion_fields_populated() {
         );
     }
 
-    // The `reserve` completion should carry a type signature in detail.
     let reserve = completions
         .completions
         .iter()
         .find(|c| c.code == "reserve(additional)")
         .expect("expected reserve(additional) in completions");
-    assert!(
-        reserve.detail.is_some(),
-        "reserve should have a detail (type signature)"
-    );
-    let detail = reserve.detail.as_ref().unwrap();
-    assert!(
-        detail.contains("usize"),
-        "reserve detail should mention its argument type, got: {detail}"
-    );
     assert_eq!(
         reserve.kind, "function",
         "method should have kind 'function'"
@@ -1216,14 +1206,6 @@ fn command_completion_fields() {
     assert_eq!(
         dep.kind, "magic",
         "command completions should have kind 'magic'"
-    );
-    assert!(
-        dep.detail.is_none(),
-        "command completions should have no detail"
-    );
-    assert!(
-        dep.documentation.is_none(),
-        "command completions should have no documentation"
     );
 }
 

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -1195,6 +1195,10 @@ fn completion_fields_populated() {
         detail.contains("usize"),
         "reserve detail should mention its argument type, got: {detail}"
     );
+    assert_eq!(
+        reserve.kind, "function",
+        "method should have kind 'function'"
+    );
 }
 
 #[test]
@@ -1209,6 +1213,10 @@ fn command_completion_fields() {
         .expect("expected :dep in command completions");
     // label must mirror code for command completions.
     assert_eq!(dep.label, dep.code);
+    assert_eq!(
+        dep.kind, "magic",
+        "command completions should have kind 'magic'"
+    );
     assert!(
         dep.detail.is_none(),
         "command completions should have no detail"
@@ -1234,11 +1242,12 @@ fn hover_at_returns_content() {
 }
 
 #[test]
-fn hover_at_unknown_symbol_returns_error() {
+fn hover_at_unknown_symbol_returns_fallback() {
     let mut ctx = new_context();
-    // Hover on something rust-analyzer can't resolve — should return Err, not panic.
     let src = "totally_unknown_function_xyz()";
-    let result = ctx.hover_at(src, src.len());
-    // The hover returning an error is acceptable; what's not acceptable is a panic.
-    let _ = result;
+    // rust-analyzer returns a "no documentation" sentinel rather than an error
+    let (plain, _) = ctx
+        .hover_at(src, src.len())
+        .expect("hover_at should not panic on an unresolvable symbol");
+    assert!(!plain.is_empty());
 }

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -150,8 +150,6 @@ fn single_statement() {
     eval!(e, assert_eq!(40i32 + 2, 42));
 }
 
-// Not sure why this is failing on mac
-#[cfg(not(target_os = "macos"))]
 #[test]
 fn save_and_restore_variables() {
     let mut e = new_context();
@@ -891,7 +889,6 @@ fn simple_completions(ctx: &mut CommandContext, code: &str) -> HashSet<String> {
         .collect()
 }
 
-// Not sure why this is failing on mac
 #[test]
 fn code_completion() {
     let mut ctx = new_context();

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -1173,7 +1173,11 @@ fn completion_fields_populated() {
 
     // Every completion should have a non-empty label.
     for c in &completions.completions {
-        assert!(!c.label.is_empty(), "label should not be empty for '{}'", c.code);
+        assert!(
+            !c.label.is_empty(),
+            "label should not be empty for '{}'",
+            c.code
+        );
     }
 
     // The `reserve` completion should carry a type signature in detail.
@@ -1205,8 +1209,14 @@ fn command_completion_fields() {
         .expect("expected :dep in command completions");
     // label must mirror code for command completions.
     assert_eq!(dep.label, dep.code);
-    assert!(dep.detail.is_none(), "command completions should have no detail");
-    assert!(dep.documentation.is_none(), "command completions should have no documentation");
+    assert!(
+        dep.detail.is_none(),
+        "command completions should have no detail"
+    );
+    assert!(
+        dep.documentation.is_none(),
+        "command completions should have no documentation"
+    );
 }
 
 #[test]

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -892,7 +892,6 @@ fn simple_completions(ctx: &mut CommandContext, code: &str) -> HashSet<String> {
 }
 
 // Not sure why this is failing on mac
-#[cfg(not(target_os = "macos"))]
 #[test]
 fn code_completion() {
     let mut ctx = new_context();
@@ -1158,4 +1157,81 @@ fn check_for_doc() {
             "ctx\n\nstruct MyStruct(usize)\n\n\nthis is my struct"
         )),
     );
+}
+
+#[test]
+fn completion_fields_populated() {
+    let mut ctx = new_context();
+    // Establish context so completions see real types.
+    ctx.execute(
+        r#"
+        fn foo() -> Vec<String> {
+            vec![]
+        }"#,
+    )
+    .unwrap();
+    let code = "foo().res";
+    let completions = ctx.completions(code, code.len()).unwrap();
+    assert!(!completions.completions.is_empty());
+
+    // Every completion should have a non-empty label.
+    for c in &completions.completions {
+        assert!(!c.label.is_empty(), "label should not be empty for '{}'", c.code);
+    }
+
+    // The `reserve` completion should carry a type signature in detail.
+    let reserve = completions
+        .completions
+        .iter()
+        .find(|c| c.code == "reserve(additional)")
+        .expect("expected reserve(additional) in completions");
+    assert!(
+        reserve.detail.is_some(),
+        "reserve should have a detail (type signature)"
+    );
+    let detail = reserve.detail.as_ref().unwrap();
+    assert!(
+        detail.contains("usize"),
+        "reserve detail should mention its argument type, got: {detail}"
+    );
+}
+
+#[test]
+fn command_completion_fields() {
+    let mut ctx = new_context();
+    // Command completions come from a different code path (no rust-analyzer).
+    let completions = ctx.completions(":de", 3).unwrap();
+    let dep = completions
+        .completions
+        .iter()
+        .find(|c| c.code == ":dep")
+        .expect("expected :dep in command completions");
+    // label must mirror code for command completions.
+    assert_eq!(dep.label, dep.code);
+    assert!(dep.detail.is_none(), "command completions should have no detail");
+    assert!(dep.documentation.is_none(), "command completions should have no documentation");
+}
+
+#[test]
+fn hover_at_returns_content() {
+    let mut ctx = new_context();
+    // Ask for hover at the end of `Vec::new` — stdlib, always available.
+    let src = "let _v: Vec<i32> = Vec::new()";
+    // Position just after `Vec::new` (before the `()`).
+    let pos = src.find("Vec::new").unwrap() + "Vec::new".len();
+    let (plain, html) = ctx
+        .hover_at(src, pos)
+        .expect("hover_at should succeed for a known stdlib item");
+    assert!(!plain.is_empty(), "plain text hover should be non-empty");
+    assert!(html.contains('<'), "html hover should contain HTML tags");
+}
+
+#[test]
+fn hover_at_unknown_symbol_returns_error() {
+    let mut ctx = new_context();
+    // Hover on something rust-analyzer can't resolve — should return Err, not panic.
+    let src = "totally_unknown_function_xyz()";
+    let result = ctx.hover_at(src, src.len());
+    // The hover returning an error is acceptable; what's not acceptable is a panic.
+    let _ = result;
 }

--- a/evcxr_jupyter/src/core.rs
+++ b/evcxr_jupyter/src/core.rs
@@ -412,6 +412,18 @@ impl Server {
                 },
             );
             reply.send(connection).await?;
+        } else if message.message_type() == "inspect_request" {
+            let reply = message.new_reply().with_content(
+                match handle_inspect_request(context, message).await {
+                    Ok(response_content) => response_content,
+                    Err(error) => object! {
+                        "status" => "error",
+                        "ename" => error.to_string(),
+                        "evalue" => "",
+                    },
+                },
+            );
+            reply.send(connection).await?;
         } else if message.message_type() == "history_request" {
             // We don't yet support history requests, but we don't want to print
             // a message in jupyter console.
@@ -761,18 +773,59 @@ async fn handle_completion_request(
             code,
             grapheme_offset_to_byte_offset(code, message.cursor_pos()),
         )?;
-        let matches: Vec<String> = completions
-            .completions
-            .into_iter()
-            .map(|completion| completion.code)
-            .collect();
+        let cursor_start = byte_offset_to_grapheme_offset(code, completions.start_offset)?;
+        let cursor_end = byte_offset_to_grapheme_offset(code, completions.end_offset)?;
+        let mut matches: Vec<String> = Vec::new();
+        let mut type_metadata: Vec<JsonValue> = Vec::new();
+        for c in &completions.completions {
+            matches.push(c.code.clone());
+            type_metadata.push(object! {
+                "text"      => c.label.clone(),
+                "type"      => "function",
+                "start"     => cursor_start,
+                "end"       => cursor_end,
+                "signature" => c.detail.clone().unwrap_or_default(),
+                "docstring" => c.documentation.clone().unwrap_or_default(),
+            });
+        }
         Ok(object! {
             "status" => "ok",
             "matches" => matches,
-            "cursor_start" => byte_offset_to_grapheme_offset(code, completions.start_offset)?,
-            "cursor_end" => byte_offset_to_grapheme_offset(code, completions.end_offset)?,
-            "metadata" => object!{},
+            "cursor_start" => cursor_start,
+            "cursor_end" => cursor_end,
+            "metadata" => object! {
+                "_jupyter_types_experimental" => type_metadata,
+            },
         })
+    })
+    .await?
+}
+
+async fn handle_inspect_request(
+    context: &Arc<std::sync::Mutex<CommandContext>>,
+    message: JupyterMessage,
+) -> Result<JsonValue> {
+    let context = Arc::clone(context);
+    tokio::task::spawn_blocking(move || {
+        let code = message.code();
+        let position = grapheme_offset_to_byte_offset(code, message.cursor_pos());
+        match context.lock().unwrap().hover_at(code, position) {
+            Ok((plain, html)) => Ok(object! {
+                "status"   => "ok",
+                "found"    => true,
+                "data"     => object! {
+                    "text/plain" => plain,
+                    "text/html"  => html,
+                },
+                "metadata" => object!{},
+            }),
+            Err(_) => Ok(object! {
+                "status"   => "ok",
+                "found"    => false,
+                "data"     => object!{},
+                "metadata" => object!{},
+            }),
+        }
     })
     .await?
 }

--- a/evcxr_jupyter/src/core.rs
+++ b/evcxr_jupyter/src/core.rs
@@ -762,6 +762,44 @@ fn kernel_info() -> JsonValue {
     }
 }
 
+/// Strips the leading self parameter (`self`, `&self`, `&mut self`) from the
+/// params section of a rust-analyzer detail string, then uses `→` for the
+/// return arrow. Non-function detail strings are returned unchanged.
+fn format_fn_detail(detail: &str) -> String {
+    let Some(fn_pos) = detail.find("fn(") else {
+        return detail.to_owned();
+    };
+    let (prefix, rest) = detail.split_at(fn_pos + 3); // prefix ends with "fn("
+    let mut depth = 1usize;
+    let Some(close) = rest.char_indices().find_map(|(i, ch)| match ch {
+        '(' => {
+            depth += 1;
+            None
+        }
+        ')' => {
+            depth -= 1;
+            if depth == 0 { Some(i) } else { None }
+        }
+        _ => None,
+    }) else {
+        return detail.to_owned();
+    };
+    let params = strip_self_param(&rest[..close]);
+    let suffix = rest[close..].replace("->", "→");
+    format!("{prefix}{params}{suffix}")
+}
+
+fn strip_self_param(params: &str) -> &str {
+    // Handles &mut self, &self, self, and self: CustomType forms
+    if !(params.starts_with("&mut self")
+        || params.starts_with("&self")
+        || params.starts_with("self"))
+    {
+        return params;
+    }
+    params.find(", ").map_or("", |i| &params[i + 2..])
+}
+
 async fn handle_completion_request(
     context: &Arc<std::sync::Mutex<CommandContext>>,
     message: JupyterMessage,
@@ -779,13 +817,21 @@ async fn handle_completion_request(
         let mut type_metadata: Vec<JsonValue> = Vec::new();
         for c in &completions.completions {
             matches.push(c.code.clone());
+            // signature: self-stripped, arrow notation — shown inline in the completion popup.
+            // docstring: raw detail (self retained) prepended as context before the prose docs.
+            let docstring = match (&c.detail, &c.documentation) {
+                (Some(sig), Some(doc)) => format!("{sig}\n\n{doc}"),
+                (Some(sig), None) => sig.clone(),
+                (None, Some(doc)) => doc.clone(),
+                (None, None) => String::new(),
+            };
             type_metadata.push(object! {
                 "text"      => c.label.clone(),
                 "type"      => c.kind,
                 "start"     => cursor_start,
                 "end"       => cursor_end,
-                "signature" => c.detail.clone().unwrap_or_default(),
-                "docstring" => c.documentation.clone().unwrap_or_default(),
+                "signature" => c.detail.as_deref().map(format_fn_detail).unwrap_or_default(),
+                "docstring" => docstring,
             });
         }
         Ok(object! {
@@ -809,7 +855,15 @@ async fn handle_inspect_request(
     tokio::task::spawn_blocking(move || {
         let code = message.code();
         let position = grapheme_offset_to_byte_offset(code, message.cursor_pos());
+        // hover_at returns Ok("No documentation found", ...) for unresolvable
+        // symbols rather than Err; treat that as found:false per Jupyter spec.
         match context.lock().unwrap().hover_at(code, position) {
+            Ok((plain, _)) if plain == "No documentation found" => Ok(object! {
+                "status"   => "ok",
+                "found"    => false,
+                "data"     => object!{},
+                "metadata" => object!{},
+            }),
             Ok((plain, html)) => Ok(object! {
                 "status"   => "ok",
                 "found"    => true,

--- a/evcxr_jupyter/src/core.rs
+++ b/evcxr_jupyter/src/core.rs
@@ -762,44 +762,6 @@ fn kernel_info() -> JsonValue {
     }
 }
 
-/// Strips the leading self parameter (`self`, `&self`, `&mut self`) from the
-/// params section of a rust-analyzer detail string, then uses `→` for the
-/// return arrow. Non-function detail strings are returned unchanged.
-fn format_fn_detail(detail: &str) -> String {
-    let Some(fn_pos) = detail.find("fn(") else {
-        return detail.to_owned();
-    };
-    let (prefix, rest) = detail.split_at(fn_pos + 3); // prefix ends with "fn("
-    let mut depth = 1usize;
-    let Some(close) = rest.char_indices().find_map(|(i, ch)| match ch {
-        '(' => {
-            depth += 1;
-            None
-        }
-        ')' => {
-            depth -= 1;
-            if depth == 0 { Some(i) } else { None }
-        }
-        _ => None,
-    }) else {
-        return detail.to_owned();
-    };
-    let params = strip_self_param(&rest[..close]);
-    let suffix = rest[close..].replace("->", "→");
-    format!("{prefix}{params}{suffix}")
-}
-
-fn strip_self_param(params: &str) -> &str {
-    // Handles &mut self, &self, self, and self: CustomType forms
-    if !(params.starts_with("&mut self")
-        || params.starts_with("&self")
-        || params.starts_with("self"))
-    {
-        return params;
-    }
-    params.find(", ").map_or("", |i| &params[i + 2..])
-}
-
 async fn handle_completion_request(
     context: &Arc<std::sync::Mutex<CommandContext>>,
     message: JupyterMessage,
@@ -817,21 +779,11 @@ async fn handle_completion_request(
         let mut type_metadata: Vec<JsonValue> = Vec::new();
         for c in &completions.completions {
             matches.push(c.code.clone());
-            // signature: self-stripped, arrow notation — shown inline in the completion popup.
-            // docstring: raw detail (self retained) prepended as context before the prose docs.
-            let docstring = match (&c.detail, &c.documentation) {
-                (Some(sig), Some(doc)) => format!("{sig}\n\n{doc}"),
-                (Some(sig), None) => sig.clone(),
-                (None, Some(doc)) => doc.clone(),
-                (None, None) => String::new(),
-            };
             type_metadata.push(object! {
-                "text"      => c.label.clone(),
-                "type"      => c.kind,
-                "start"     => cursor_start,
-                "end"       => cursor_end,
-                "signature" => c.detail.as_deref().map(format_fn_detail).unwrap_or_default(),
-                "docstring" => docstring,
+                "text"  => c.label.clone(),
+                "type"  => c.kind,
+                "start" => cursor_start,
+                "end"   => cursor_end,
             });
         }
         Ok(object! {

--- a/evcxr_jupyter/src/core.rs
+++ b/evcxr_jupyter/src/core.rs
@@ -781,7 +781,7 @@ async fn handle_completion_request(
             matches.push(c.code.clone());
             type_metadata.push(object! {
                 "text"      => c.label.clone(),
-                "type"      => "function",
+                "type"      => c.kind,
                 "start"     => cursor_start,
                 "end"       => cursor_end,
                 "signature" => c.detail.clone().unwrap_or_default(),


### PR DESCRIPTION
Richer completions for LSP requests. Now including 
- Types
- Docstrings where available

Previously, shift+tab didn't work the way we'd expect, now it does.

Manually tested, looks good from there. 

Feedback welcome, I'm not amazing at rust, and not familiar with this repo. But I've taken a look at the tests and they seem valid.

Totally AI but I've read for sanity and I think it looks useful. I think a squash and merge would be appropriate here but can squash on my end if that's preferred, let me know.

Will close #466.