### PR TITLE
Preserve invalid code for compiler diagnostics

### DIFF
--- a/evcxr/src/statement_splitter.rs
+++ b/evcxr/src/statement_splitter.rs
@@ -26,6 +26,11 @@ pub(crate) fn split_into_statements(code: &str) -> Vec<OriginalUserCode<'_>> {
         &(prelude.to_owned() + code + "\n}"),
         crate::rust_analyzer::EDITION,
     );
+    let first_error_byte = parsed_file
+        .errors()
+        .iter()
+        .map(|error| usize::from(error.range().start()).saturating_sub(prelude.len()))
+        .min();
     let mut start_byte = 0;
     if let Some(stmt_list) = parsed_file
         .syntax_node()
@@ -42,10 +47,17 @@ pub(crate) fn split_into_statements(code: &str) -> Vec<OriginalUserCode<'_>> {
             // With the possible exception of the first node, We want to include
             // whitespace after nodes rather than before, so our end is the
             // start of the next node, or failing that the end of the code.
-            let end = next
+            let mut end = next
                 .map(|next| usize::from(next.text_range().start()) - prelude.len())
                 .unwrap_or(code.len())
                 .min(code.len());
+            let child_end = usize::from(child.text_range().end())
+                .saturating_sub(prelude.len())
+                .min(code.len());
+            // Keep error-recovery nodes together so rustc sees the original invalid code.
+            if first_error_byte.is_some_and(|first_error| first_error <= child_end) {
+                end = code.len();
+            }
             if start_byte == end {
                 break;
             }
@@ -180,6 +192,18 @@ mod test {
         let out = split_into_statements(code);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].code, "#[derive(Debug)]");
+    }
+
+    #[test]
+    fn invalid_function_parameter_is_not_split() {
+        let code = "fn do_it(in: u8) {}";
+        assert_eq!(split_and_get_text(code), vec![code]);
+
+        let code = "let a = 1; fn do_it(in: u8) {}";
+        assert_eq!(
+            split_and_get_text(code),
+            vec!["let a = 1; ", "fn do_it(in: u8) {}"]
+        );
     }
 
     fn node_kinds(statements: &[OriginalUserCode]) -> Vec<SyntaxKind> {

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -1052,6 +1052,26 @@ fn assert_no_errors(ctx: &mut CommandContext, code: &str) {
 }
 
 #[test]
+fn check_reports_invalid_parameter_name() {
+    let mut ctx = new_context();
+    let errors = ctx.check("fn do_it(in: u8) {}").unwrap();
+    let messages: Vec<String> = errors.iter().map(|error| error.message()).collect();
+
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("expected parameter name") && message.contains("`in`")),
+        "{messages:#?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|message| !message.contains("closing delimiter")),
+        "{messages:#?}"
+    );
+}
+
+#[test]
 fn check_for_errors() {
     let mut ctx = new_context();
 


### PR DESCRIPTION
Fixes #495.

When rust-analyzer recovered from a parse error, Evcxr treated each recovery node as a separate statement. This change keeps the affected node and the remaining input together so rustc receives the original invalid function.

Tests:
- `cargo build -j 1`
- `cargo test -j 1 -- --test-threads 1`
- `cargo fmt --all -- --check`
- `cargo clippy -j 1`