### PR TITLE
docs(jupyter): add a Colab edition of the tour notebook

### DIFF
--- a/evcxr_jupyter/README.md
+++ b/evcxr_jupyter/README.md
@@ -1,6 +1,8 @@
 # Evcxr Jupyter Kernel
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/evcxr/evcxr/blob/main/evcxr_jupyter/samples/evcxr_jupyter_tour.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/evcxr/evcxr/blob/main/evcxr_jupyter/samples/evcxr_jupyter_tour_colab.ipynb)
+
+The Colab notebook runs on Colab's Python kernel through [colab-rust](https://github.com/xavierforge/colab-rust), a community maintained `%%rust` cell magic.
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/evcxr/evcxr/main?filepath=evcxr_jupyter%2Fsamples%2Fevcxr_jupyter_tour.ipynb)
 

--- a/evcxr_jupyter/samples/evcxr_jupyter_tour.ipynb
+++ b/evcxr_jupyter/samples/evcxr_jupyter_tour.ipynb
@@ -4,19 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Google Colab Rust Setup\n",
+    "# Running on Google Colab\n",
     "\n",
-    "The following cell is used to set up and spin up a Jupyter Notebook environment with a Rust kernel using Nix and IPC Proxy. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!wget -qO- https://gist.github.com/wiseaidev/2af6bef753d48565d11bcd478728c979/archive/3f6df40db09f3517ade41997b541b81f0976c12e.tar.gz | tar xvz --strip-components=1\n",
-    "!bash setup_evcxr_kernel.sh"
+    "On Google Colab, use the Colab edition of this notebook: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/evcxr/evcxr/blob/main/evcxr_jupyter/samples/evcxr_jupyter_tour_colab.ipynb)."
    ]
   },
   {
@@ -353,6 +343,16 @@
    "metadata": {},
    "source": [
     "We can also return images using add-on crates like `evcxr_image`, which adds support for displaying RGB and grayscale images in Evcxr. Note, the version of the `image` crate used must match the version used by `evcxr_image`, otherwise the types will effectively be different and the image won't get displayed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, adding a dependency causes everything to be recompiled. Variables whose ",
+    "types were defined in earlier cells, such as `m` above, can't be kept across ",
+    "the recompile, so evcxr drops them and tells you. If you want to keep such ",
+    "variables, add your dependencies first."
    ]
   },
   {

--- a/evcxr_jupyter/samples/evcxr_jupyter_tour_colab.ipynb
+++ b/evcxr_jupyter/samples/evcxr_jupyter_tour_colab.ipynb
@@ -1,0 +1,736 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Google Colab Rust Setup\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/evcxr/evcxr/blob/main/evcxr_jupyter/samples/evcxr_jupyter_tour_colab.ipynb)\n",
+    "\n",
+    "This is the Colab edition of the tour. It stays on Colab's Python kernel and runs evcxr through the `%%rust` cell magic from [colab-rust](https://github.com/xavierforge/colab-rust), a community maintained project. That works on GPU runtimes too, and you can mix Python and Rust cells. Run the next two cells first to set that up. It usually takes well under a minute, or about ten minutes if evcxr has to be built from source.\n",
+    "\n",
+    "Note that this notebook is meant for Google Colab: the setup cell installs Rust and evcxr into the runtime, so it shouldn't be run on a local Jupyter. Colab also highlights `%%rust` cells as Python, so Rust keywords won't be coloured.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!curl -fsSL -o setup.sh https://raw.githubusercontent.com/xavierforge/colab-rust/v0.1.4/setup.sh\n",
+    "!COLAB_RUST_REF=v0.1.4 bash setup.sh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 2,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "✅ colab_rust 0.1.4 loaded — use %%rust in any cell\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext colab_rust"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tour of the EvCxR Jupyter Kernel\n",
+    "For those not already familiar with Jupyter notebook, it lets you write code into \"cells\" like the box below. Cells can alternatively contain markdown, like this text here. Each code cell is compiled and executed separately, but variables, defined functions etc persist between cells. Here, each Rust cell starts with `%%rust`. Everything after that line gets sent to evcxr.\n",
+    "\n",
+    "## Printing to outputs and evaluating expressions\n",
+    "Lets print something to stdout and stderr then return a final expression to see how that's presented. Note that stdout and stderr are separate streams, so may not appear in the same order is their respective print statements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Hello world\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Hello error\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\"Hello world\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "println!(\"Hello world\");\n",
+    "eprintln!(\"Hello error\");\n",
+    "format!(\"Hello {}\", \"world\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assigning and making use of variables\n",
+    "We define a variable `message`, then in the subsequent cell, modify the string and finally print it out. We could also do all this in the one cell if we wanted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "let mut message = \"Hello \".to_owned();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "message.push_str(\"world!\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\"Hello world!\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "message"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining and redefining functions\n",
+    "Next we'll define a function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "pub fn fib(x: i32) -> i32 {\n",
+    "    if x <= 2 {0} else {fib(x - 2) + fib(x - 1)}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "(1..13).map(fib).collect::<Vec<i32>>()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hmm, that doesn't look right. Lets redefine the function. In practice, we'd go back and edit the function above and reevalute it, but here, lets redefine it in a separate cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "pub fn fib(x: i32) -> i32 {\n",
+    "    if x <= 2 {1} else {fib(x - 2) + fib(x - 1)}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "let values = (1..13).map(fib).collect::<Vec<i32>>();\n",
+    "values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spawning a separate thread and communicating with it\n",
+    "We can spawn a thread to do stuff in the background, then continue executing code in other cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "use std::sync::{Mutex, Arc};\n",
+    "let counter = Arc::new(Mutex::new(0i32));\n",
+    "std::thread::spawn({\n",
+    "    let counter = Arc::clone(&counter);\n",
+    "    move || {\n",
+    "        for i in 1..300 {\n",
+    "            *counter.lock().unwrap() += 1;\n",
+    "            std::thread::sleep(std::time::Duration::from_millis(100));\n",
+    "        }\n",
+    "}});"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "15\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "*counter.lock()?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "74\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "*counter.lock()?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading external crates\n",
+    "We can load external crates. This one takes a while to compile, but once it's compiled, subsequent cells shouldn't need to recompile it, so it should be much quicker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "   Compiled 2 crates in 2s"
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\"AQIDBA==\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    ":dep base64 = \"0.10.1\"\n",
+    "base64::encode(&vec![1, 2, 3, 4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Customizing how types are displayed\n",
+    "We can also customize how our types are displayed, including presenting them as HTML. Here's an example where we define a custom display function for a type `Matrix`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "use std::fmt::Debug;\n",
+    "pub struct Matrix<T> {pub values: Vec<T>, pub row_size: usize}\n",
+    "impl<T: Debug> Matrix<T> {\n",
+    "    pub fn evcxr_display(&self) {\n",
+    "        let mut html = String::new();\n",
+    "        html.push_str(\"<table>\");\n",
+    "        for r in 0..(self.values.len() / self.row_size) {\n",
+    "            html.push_str(\"<tr>\");\n",
+    "            for c in 0..self.row_size {\n",
+    "                html.push_str(\"<td>\");\n",
+    "                html.push_str(&format!(\"{:?}\", self.values[r * self.row_size + c]));\n",
+    "                html.push_str(\"</td>\");\n",
+    "            }\n",
+    "            html.push_str(\"</tr>\");\n",
+    "        }\n",
+    "        html.push_str(\"</table>\");\n",
+    "        println!(\"EVCXR_BEGIN_CONTENT text/html\\n{}\\nEVCXR_END_CONTENT\", html);\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<table><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>4</td><td>5</td><td>6</td></tr><tr><td>7</td><td>8</td><td>9</td></tr></table>"
+      ]
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "let m = Matrix {values: vec![1,2,3,4,5,6,7,8,9], row_size: 3};\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also return images using add-on crates like `evcxr_image`, which adds support for displaying RGB and grayscale images in Evcxr. Note, the version of the `image` crate used must match the version used by `evcxr_image`, otherwise the types will effectively be different and the image won't get displayed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, adding a dependency causes everything to be recompiled. Variables whose types were defined in earlier cells, such as `m` above, can't be kept across the recompile, so evcxr drops them and tells you. If you want to keep such variables, add your dependencies first.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "   Compiled 21 crates in 43s"
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "The type of the variable m was redefined, so was lost.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAGBklEQVR4nO3TCVIcRxBAUfn+h7aRRUgIhpleasnlvQiHBczSVZn/nx8//v3x7u3f0Mvb0v8O4M3bj9DI28Z/DODN22+gi1/rrgGa+r3rGqCjj4uuAdr5tOUaoJevK64BGnm43xqgi++WWwO08GSzNUB9z9daAxT3cqc1QGVHFloDlHVwmzVATcdXWQMUdGqPNUA1Z5dYA5RyYYM1QB3X1lcDFHF5dzVABXcWVwOkd3NrNUBu91dWAyQ2ZF81QFajllUDpDRwUzVAPmPXVAMkM3xHNUAmMxZUA6QxaTs1QA7zVlMDJDB1LzVAdLOXUgOEtmAjNUBca9ZRAwS1bBc1QEQrF1EDhLN4CzVALOtXUAMEsmX/NEAUu5ZPA4SwcfM0wH57104DbLZ95zTAThEWTgNsE2TbNMAecVZNA2wQas80wGrRlkwDLBVwwzTAOjHXSwMsEna3NMAKkRdLA0wXfKs0wFzxV0oDTJRinzTALFmWSQNMkWiTNMB4udZIAwyWboc0wEgZF0gDDJN0ezTAGHlXRwMMkHpvNMBd2ZdGA9xSYGM0wHU11kUDXFRmVzTAFZUWRQOcVmxLNMA59VZEA5xQcj80wFFVl0MDHFJ4MzTAa7XXQgO8UH4nNMAzHRZCA3yryTZogMf6rIIGeKDVHmiAz7otgQb4S8MN0AB/9By/BnjXdvYa4KfOg9cA3aeuge6MXAOtmfcbDfRl2L9ooCmT/k0DHRnzRxpox4w/0UAvBvyVBhox3Yc00IXRfkcDLZjrExqoz1Cf00BxJvqSBiozziM0UJZZHqSBmgzyOA0UZIqnaKAaIzxLA6WY3wUaqMPwrtFAESZ3mQYqMLY7NJCemd2kgdwM7D4NJGZaQ2ggK6MaRQMpmdNAGsjHkMbSQDImNJwGMjGeGTSQhtlMooEcDGYeDSRgKlNpIDojmU0DoZnHAhqIyzDW0EBQJrGMBiIyhpU0EI4ZLKaBWAxgPQ0E4va30EAUrn4XDYTg3jfSwH4ufS8NbObGt9PATq47Ag1s466D0MAeLjoODWzglkPRwGquOBoNLOV+A9LAOi43Jg0s4mbD0sAKrjUyDUznToPTwFwuND4NTOQ2U9DALK4yCw1M4R4T0cB4LjEXDQzmBtPRwEiuLyMNDOPuktLAGC4uLw0M4NZS08Bdriw7DdzivgrQwHUuqwYNXOSmytDAFa6pEg2c5o6K0cA5LqgeDZzgdkrSwFGupioNHOJeCtPAay6lNg284EbK08AzrqMDDXzLXTShgcdcRB8aeMAttKKBz1xBNxr4S/fzt6SBP1ofvjENvOt78vY08FPTY/M/DbQ8Mx90b6DdgfmidQO9Tss3+jbQ6Kg81bSBLufkgI4NtDgkh7VroP4JOalXA8WPxyWNGqh8Nm7o0kDZg3FbiwZqnopB6jdQ8EgMVbyBaudhgsoNlDoM05RtoM5JmKxmA0WOwRIFG6hwBhaq1kD6A7BcqQZyPz2b1Gkg8aOzVZEGsj43AVRoIOVDE0b6BvI9McHkbiDZ4xJS4gYyPSuBZW0gzYMSXsoGcjwlSeRrIMEjkkqyBqI/HwllaiD0w5FWmgbiPhnJ5Wgg6GNRQoIGIj4ThURvINwDUU7oBmI9DUXFbSDQo1Ba0AaiPAcNRGwgxEPQRrgG9j8BzcRqYPPX01KgBnZ+N41FaWDbF9NeiAb2fCv8b38DG74SPtjcwOrvgy92NrD0y+Ab2xpY903w1J4GFn0NHLChgRXfAYetbmD6F8BJSxuY++lwyboGJn403LCogVmfC7etaGDKh8Ig0xsY/4kw1NwGBn8cTDCxgZGfBdPMamDYB8FkUxoY8ymwxPgGBnwELDS4gbvvh+VGNnDrzbDJsAauvxO2GtPAxbdBAAMauPIeCONuA6ffAMHcauDcqyGk6w2ceCkEdrGBo6+D8K40cOhFkMTpBl6/AlI518CLP0NCJxp49jdI62gD3/4BkjvUwOPfQgmvG3jwKyjkRQOff4ZynjXw1w9Q1LcN/PkXlPa4gff/QQMPGvj5H7TxuQEB0M1fDQiAhv40IAB6em/gP4B1AQ2EIi+6AAAAAElFTkSuQmCC"
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    ":dep image = \"0.23\"\n",
+    ":dep evcxr_image = \"1.1\"\n",
+    "use evcxr_image::ImageDisplay;\n",
+    "\n",
+    "image::ImageBuffer::from_fn(256, 256, |x, y| {\n",
+    "    if (x as i32 - y as i32).abs() < 3 {\n",
+    "        image::Rgb([0, 0, 255])\n",
+    "    } else {\n",
+    "        image::Rgb([0, 0, 0])\n",
+    "    }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display of compilation errors\n",
+    "Here's how compilation errors are presented. Here we forgot an & and passed a String instead of an &str."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "\u001b[31m[E0308] Error:\u001b[0m mismatched types\n",
+      "   \u001b[38;5;246m╭\u001b[0m\u001b[38;5;246m─\u001b[0m\u001b[38;5;246m[\u001b[0m command_17:1:1 \u001b[38;5;246m]\u001b[0m\n",
+      "   \u001b[38;5;246m│\u001b[0m\n",
+      " \u001b[38;5;246m2 │\u001b[0m \u001b[38;5;249ms\u001b[0m\u001b[38;5;249m.\u001b[0m\u001b[38;5;249mp\u001b[0m\u001b[38;5;249mu\u001b[0m\u001b[38;5;249ms\u001b[0m\u001b[38;5;249mh\u001b[0m\u001b[38;5;249m_\u001b[0m\u001b[38;5;249ms\u001b[0m\u001b[38;5;249mt\u001b[0m\u001b[38;5;249mr\u001b[0m\u001b[38;5;249m(\u001b[0m\u001b[38;5;54mf\u001b[0m\u001b[38;5;54mo\u001b[0m\u001b[38;5;54mr\u001b[0m\u001b[38;5;54mm\u001b[0m\u001b[38;5;54ma\u001b[0m\u001b[38;5;54mt\u001b[0m\u001b[38;5;54m!\u001b[0m\u001b[38;5;54m(\u001b[0m\u001b[38;5;54m\"\u001b[0m\u001b[38;5;54mf\u001b[0m\u001b[38;5;54mo\u001b[0m\u001b[38;5;54mo\u001b[0m\u001b[38;5;54m \u001b[0m\u001b[38;5;54m{\u001b[0m\u001b[38;5;54m}\u001b[0m\u001b[38;5;54m\"\u001b[0m\u001b[38;5;54m,\u001b[0m\u001b[38;5;54m \u001b[0m\u001b[38;5;54m4\u001b[0m\u001b[38;5;54m2\u001b[0m\u001b[38;5;54m)\u001b[0m\u001b[38;5;249m)\u001b[0m\u001b[38;5;249m;\u001b[0m\n",
+      " \u001b[38;5;240m  │\u001b[0m            \u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m┬\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m  \n",
+      " \u001b[38;5;240m  │\u001b[0m                      \u001b[38;5;54m╰\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m\u001b[38;5;54m─\u001b[0m expected `&str`, found `String`\n",
+      "\u001b[38;5;246m───╯\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "let mut s = String::new();\n",
+    "s.push_str(format!(\"foo {}\", 42));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Async await\n",
+    "Async functions can be called and the results awaited. Currently this uses Tokio as the executor. The first run of code that uses await will likely be slow while Tokio is compiled. We explicitly add tokio as a dependency so that we can turn on the \"full\" feature. This is needed for TcpStream. This example also demostrates use of the question mark operator, which upon finding that the result contained an error, prints it to stderr."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "   Compiled 15 crates in 22s"
+      ]
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    ":dep tokio = {version = \"0.2\", features = [\"full\"]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "invalid port value\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    "let mut stream : tokio::net::TcpStream = tokio::net::TcpStream::connect(\"127.0.0.1:99999\").await?;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, we needed to give an explicit type to the stream variable, because rustc, at least at the time of writing suggests `tokio::net::tcp::TcpStream`, which is private. We need to explicitly provide the public alias in such cases.\n",
+    "\n",
+    "Now let's try again with a valid port number. First, make something listen on port 6543. Since we're still on the Python kernel, we can do that from a Python cell.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 21,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "listening on 127.0.0.1:6543\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Listen on port 6543 and hand the one expected connection to a thread.\n",
+    "import socket\n",
+    "import threading\n",
+    "\n",
+    "received = []\n",
+    "server = socket.socket()\n",
+    "server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n",
+    "server.bind((\"127.0.0.1\", 6543))\n",
+    "server.listen(1)\n",
+    "\n",
+    "def accept_one():\n",
+    "    conn, _ = server.accept()\n",
+    "    received.append(conn.recv(1024).decode())\n",
+    "    conn.close()\n",
+    "    server.close()\n",
+    "\n",
+    "listener = threading.Thread(target=accept_one, daemon=True)\n",
+    "listener.start()\n",
+    "print(\"listening on 127.0.0.1:6543\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "let mut stream : tokio::net::TcpStream = tokio::net::TcpStream::connect(\"127.0.0.1:6543\").await?;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%rust\n",
+    "use tokio::io::AsyncWriteExt;\n",
+    "stream.write(b\"Hello, world!\\n\").await?;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point, our listener should have received \"Hello, world!\". Let's check.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 24,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "['Hello, world!\\n']\n"
+     ]
+    }
+   ],
+   "source": [
+    "listener.join(timeout=5)\n",
+    "print(received)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Seeing what variables have been defined\n",
+    "We can print a table of defined variables and their types with the :vars command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<table><tr><th>Variable</th><th>Type</th></tr><tr><td>stream</td><td>tokio::net::TcpStream</td><tr><tr><td>values</td><td>Vec&lt;i32&gt;</td><tr><tr><td>message</td><td>String</td><tr><tr><td>counter</td><td>Arc&lt;Mutex&lt;i32&gt;&gt;</td><tr></table>"
+      ],
+      "text/plain": [
+       "stream: tokio::net::TcpStream\n",
+       "values: Vec<i32>\n",
+       "message: String\n",
+       "counter: Arc<Mutex<i32>>\n"
+      ]
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    ":vars"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Other built-in commands can be found via :help"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<tr><td>:allow_static_linking</td><td>Set whether to allow static linking of dependencies (0/1)</td></tr>\n",
+       "<tr><td>:build_env</td><td>Set environment variables when building code (key=value)</td></tr>\n",
+       "<tr><td>:cache</td><td>Set cache size in MiB, or 0 to disable.</td></tr>\n",
+       "<tr><td>:clear</td><td>Clear all state, keeping compilation cache</td></tr>\n",
+       "<tr><td>:clear_cache</td><td>Clear the cache used by the :cache command</td></tr>\n",
+       "<tr><td>:codegen_backend</td><td>Set/print the codegen backend. Requires nightly</td></tr>\n",
+       "<tr><td>:dep</td><td>Add dependency. e.g. :dep regex = \"1.0\"</td></tr>\n",
+       "<tr><td>:doc</td><td>show the documentation of a variable, keyword, type or module</td></tr>\n",
+       "<tr><td>:efmt</td><td>Set the formatter for errors returned by ?</td></tr>\n",
+       "<tr><td>:env</td><td>Set an environment variable (key=value)</td></tr>\n",
+       "<tr><td>:explain</td><td>Print explanation of last error</td></tr>\n",
+       "<tr><td>:fmt</td><td>Set output formatter (default: {:?})</td></tr>\n",
+       "<tr><td>:help</td><td>Print command help</td></tr>\n",
+       "<tr><td>:internal_debug</td><td>Toggle various internal debugging code</td></tr>\n",
+       "<tr><td>:last_compile_dir</td><td>Print the directory in which we last compiled</td></tr>\n",
+       "<tr><td>:last_error_json</td><td>Print the last compilation error as JSON (for debugging)</td></tr>\n",
+       "<tr><td>:linker</td><td>Set/print linker. Supported: system, lld, mold</td></tr>\n",
+       "<tr><td>:load_config</td><td>Reloads startup configuration files. Accepts optional flag `--quiet` to suppress logging.</td></tr>\n",
+       "<tr><td>:offline</td><td>Set offline mode when invoking cargo (0/1)</td></tr>\n",
+       "<tr><td>:opt</td><td>Set optimization level (0/1/2)</td></tr>\n",
+       "<tr><td>:preserve_vars_on_panic</td><td>Try to keep vars on panic (0/1)</td></tr>\n",
+       "<tr><td>:quit</td><td>Quit evaluation and exit</td></tr>\n",
+       "<tr><td>:restart</td><td>Restart child process</td></tr>\n",
+       "<tr><td>:sccache</td><td>Set whether to use sccache (0/1).</td></tr>\n",
+       "<tr><td>:show_deps</td><td>Show the current dependencies</td></tr>\n",
+       "<tr><td>:t</td><td>Short version of :type</td></tr>\n",
+       "<tr><td>:time_passes</td><td>Toggle printing of rustc pass times (requires nightly)</td></tr>\n",
+       "<tr><td>:timing</td><td>Toggle printing of how long evaluations take</td></tr>\n",
+       "<tr><td>:toolchain</td><td>Set which toolchain to use (e.g. nightly)</td></tr>\n",
+       "<tr><td>:type</td><td>Show variable type</td></tr>\n",
+       "<tr><td>:types</td><td>Toggle printing of types</td></tr>\n",
+       "<tr><td>:vars</td><td>List bound variables and their types</td></tr>\n",
+       "<tr><td>:version</td><td>Print Evcxr version</td></tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       ":allow_static_linking Set whether to allow static linking of dependencies (0/1)\n",
+       ":build_env        Set environment variables when building code (key=value)\n",
+       ":cache            Set cache size in MiB, or 0 to disable.\n",
+       ":clear            Clear all state, keeping compilation cache\n",
+       ":clear_cache      Clear the cache used by the :cache command\n",
+       ":codegen_backend  Set/print the codegen backend. Requires nightly\n",
+       ":dep              Add dependency. e.g. :dep regex = \"1.0\"\n",
+       ":doc              show the documentation of a variable, keyword, type or module\n",
+       ":efmt             Set the formatter for errors returned by ?\n",
+       ":env              Set an environment variable (key=value)\n",
+       ":explain          Print explanation of last error\n",
+       ":fmt              Set output formatter (default: {:?})\n",
+       ":help             Print command help\n",
+       ":internal_debug   Toggle various internal debugging code\n",
+       ":last_compile_dir Print the directory in which we last compiled\n",
+       ":last_error_json  Print the last compilation error as JSON (for debugging)\n",
+       ":linker           Set/print linker. Supported: system, lld, mold\n",
+       ":load_config      Reloads startup configuration files. Accepts optional flag `--quiet` to suppress logging.\n",
+       ":offline          Set offline mode when invoking cargo (0/1)\n",
+       ":opt              Set optimization level (0/1/2)\n",
+       ":preserve_vars_on_panic Try to keep vars on panic (0/1)\n",
+       ":quit             Quit evaluation and exit\n",
+       ":restart          Restart child process\n",
+       ":sccache          Set whether to use sccache (0/1).\n",
+       ":show_deps        Show the current dependencies\n",
+       ":t                Short version of :type\n",
+       ":time_passes      Toggle printing of rustc pass times (requires nightly)\n",
+       ":timing           Toggle printing of how long evaluations take\n",
+       ":toolchain        Set which toolchain to use (e.g. nightly)\n",
+       ":type             Show variable type\n",
+       ":types            Toggle printing of types\n",
+       ":vars             List bound variables and their types\n",
+       ":version          Print Evcxr version\n"
+      ]
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "%%rust\n",
+    ":help"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a Colab edition of the evcxr_jupyter tour that runs on Colab's Python kernel through the `%%rust` cell magic from [colab-rust](https://github.com/xavierforge/colab-rust), replaces the tour's Nix-based Colab setup cells with a one-line pointer to it, and points the Open In Colab badge at the new notebook.

## Why

The tour's current Colab setup cell (the Nix + IPC-proxy gist from 03f67c9) fails on Colab GPU runtimes. Its `ln -s /root/.nix-profile/bin /opt/bin` lands inside the `/opt/bin` directory that Colab's GPU image already ships (it holds the nvidia tools), so `nix-env` is never on PATH and evcxr never gets installed. This is the tail of that cell's output on a T4 runtime, 2026-09-03.

```
Nix was installed successfully!
setup_evcxr_kernel.sh: line 11: nix-env: command not found
setup_evcxr_kernel.sh: line 12: evcxr_jupyter: command not found
$ ls -la /opt/bin
drwxr-xr-x 2 root root 4096 Aug 31 13:47 .nvidia
lrwxrwxrwx 1 root root   40 Sep  3 13:36 nvidia-cuda-mps-control -> /opt/bin/.nvidia/nvidia-cuda-mps-control
```

On CPU runtimes it installs, but the kernel switch it needs is fragile. The setup cell has to be run from the Python runtime, twice, before the Rust kernel shows up, and picking the wrong kernel means starting over. I hit the GPU wall two years ago in #147 without finding the cause. The colab-rust project is the "automatic builds" idea from that thread with GitHub Actions and Releases in place of Google Drive. A prebuilt evcxr_jupyter installs in 16 to 18 s (measured on T4 and CPU runtimes), the notebook stays on the Python kernel, and it works on GPU runtimes.

## Testing

- The notebook ran top to bottom on both a Colab T4 runtime and a CPU runtime (colab-rust 0.1.4, evcxr_jupyter 0.22.0, Rust stable 1.98), and the committed outputs are from the CPU run. Every code cell executed, the HTML table and the PNG render, the listener receives `['Hello, world!\n']`, and the two cells that are meant to fail do so on stderr. The install cell's output is cleared because its version lines are run-specific.
- `nbformat.validate` passes for both notebooks, and the original tour re-serialises byte-identically, so its diff is confined to the touched cells. No Rust code is touched.
